### PR TITLE
Polygon rendering & Eigen compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,7 @@ configuration:
   - Release
 branches:
   only:
-    - master
-    - develop
+    - /.*/
 before_build:
   - cmake -H. -Bbuild -A%PLATFORM%
 build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: cpp
 # configure branches to build
 branches:
   only:
-  - master
-  - develop
+  - /.*/
 
 # build configuration matrix
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.
 ### Added
 
 - Add constructors using initializer lists to Matrix/Vector classes
+- Add assignment from and cast from Eigen matrices and vectors
 
 ### Fixed
 

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -247,3 +247,11 @@
 	journal = {Computer Graphics Forum}
 }
 
+@article{alexa_2011_laplace,
+ author = {Alexa, Marc and Wardetzky, Max},
+ title = {Discrete Laplacians on General Polygonal Meshes},
+ year = {2011},
+ volume = {30},
+ number = {4},
+ journal = {ACM Transactions on Graphics}
+}

--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -237,7 +237,12 @@ public:
     Scalar* data() { return data_; }
 
     //! normalize matrix/vector by dividing through Frobenius/Euclidean norm
-    void normalize() { *this /= norm(*this); }
+    void normalize() 
+    { 
+        Scalar n = norm(*this);
+        n = (n > std::numeric_limits<Scalar>::min()) ? 1.0 / n : 0.0;
+        *this *= n;
+    }
 
     //! divide matrix by scalar
     Matrix<Scalar, M, N>& operator/=(const Scalar s)

--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -167,7 +167,7 @@ public:
         {
             assert( m.size()==size() );
             for (int i = 0; i < size(); ++i)
-                (*this)[i] = m[i];
+                (*this)[i] = m(i);
         }
         else
         {
@@ -196,7 +196,7 @@ public:
         {
             assert( m.size()==size() );
             for (int i = 0; i < size(); ++i)
-                (*this)[i] = m[i];
+                (*this)[i] = m(i);
         }
         else
         {

--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -158,6 +158,26 @@ public:
     }
     // clang-format on
 
+    //! construct from Eigen
+    template <typename Derived>
+    Matrix(const Eigen::MatrixBase<Derived>& m)
+    {
+        // don't distinguish between row and column vectors
+        if (m.rows()==1 || m.cols()==1)
+        {
+            assert( m.size()==size() );
+            for (int i = 0; i < size(); ++i)
+                (*this)[i] = m[i];
+        }
+        else
+        {
+            assert(m.rows()==rows() && m.cols()==cols());
+            for (int i = 0; i < rows(); ++i)
+                for (int j = 0; j < cols(); ++j)
+                    (*this)(i,j) = m(i,j);
+        }
+    }
+
     //! copy constructor from other scalar type
     //! is also invoked for type-casting
     template <typename OtherScalarType>

--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <limits>
 #include <initializer_list>
+#include <Eigen/Dense>
 
 //=============================================================================
 
@@ -164,6 +165,38 @@ public:
     {
         for (int i = 0; i < size(); ++i)
             data_[i] = static_cast<Scalar>(m[i]);
+    }
+
+    //! assign from Eigen
+    template <typename Derived>
+    Matrix<Scalar, M, N>& operator=(const Eigen::MatrixBase<Derived>& m)
+    {
+        // don't distinguish between row and column vectors
+        if (m.rows()==1 || m.cols()==1)
+        {
+            assert( m.size()==size() );
+            for (int i = 0; i < size(); ++i)
+                (*this)[i] = m[i];
+        }
+        else
+        {
+            assert(m.rows()==rows() && m.cols()==cols());
+            for (int i = 0; i < rows(); ++i)
+                for (int j = 0; j < cols(); ++j)
+                    (*this)(i,j) = m(i,j);
+        }
+        return *this;
+    }
+
+    //! cast to Eigen
+    template <typename OtherScalar>
+    operator Eigen::Matrix<OtherScalar, M, N>() const
+    {
+        Eigen::Matrix<OtherScalar, M, N> m;
+        for (int i = 0; i < rows(); ++i)
+            for (int j = 0; j < cols(); ++j)
+                m(i,j) = static_cast<OtherScalar>((*this)(i,j));
+        return m;
     }
 
     //! return identity matrix (only for square matrices, N==M)

--- a/src/pmp/algorithms/SurfaceFairing.cpp
+++ b/src/pmp/algorithms/SurfaceFairing.cpp
@@ -140,15 +140,14 @@ void SurfaceFairing::fair(unsigned int k)
     const unsigned int n = vertices.size();
     SparseMatrix A(n, n);
     Eigen::MatrixXd B(n, 3);
+    dvec3 b;
 
     std::map<Vertex, double> row;
     std::vector<Triplet> triplets;
 
     for (unsigned int i = 0; i < n; ++i)
     {
-        B(i, 0) = 0.0;
-        B(i, 1) = 0.0;
-        B(i, 2) = 0.0;
+        b = dvec3(0.0);
 
         setup_matrix_row(vertices[i], vweight_, eweight_, k, row);
 
@@ -163,11 +162,11 @@ void SurfaceFairing::fair(unsigned int k)
             }
             else
             {
-                B(i, 0) -= w * points_[v][0];
-                B(i, 1) -= w * points_[v][1];
-                B(i, 2) -= w * points_[v][2];
+                b -= w * static_cast<dvec3>(points_[v]);
             }
         }
+
+        B.row(i) = (Eigen::Vector3d) b;
     }
 
     A.setFromTriplets(triplets.begin(), triplets.end());
@@ -183,10 +182,7 @@ void SurfaceFairing::fair(unsigned int k)
     else
     {
         for (unsigned int i = 0; i < n; ++i)
-        {
-            auto v = vertices[i];
-            points_[v] = Point(X(idx_[v], 0), X(idx_[v], 1), X(idx_[v], 2));
-        }
+            points_[vertices[i]] = X.row(i);
     }
 }
 

--- a/src/pmp/algorithms/SurfaceHoleFilling.cpp
+++ b/src/pmp/algorithms/SurfaceHoleFilling.cpp
@@ -456,9 +456,7 @@ void SurfaceHoleFilling::relaxation()
         else
             triplets.emplace_back(i, idx[v], c);
 
-        B(i, 0) = b[0];
-        B(i, 1) = b[1];
-        B(i, 2) = b[2];
+        B.row(i) = (Eigen::Vector3d) b;
     }
 
     // solve least squares system
@@ -477,10 +475,7 @@ void SurfaceHoleFilling::relaxation()
     // copy solution to mesh vertices
     for (int i = 0; i < n; ++i)
     {
-        Vertex v = vertices[i];
-        points_[v][0] = X(i, 0);
-        points_[v][1] = X(i, 1);
-        points_[v][2] = X(i, 2);
+        points_[vertices[i]] = X.row(i);
     }
 
     // clean up

--- a/src/pmp/algorithms/SurfaceNormals.h
+++ b/src/pmp/algorithms/SurfaceNormals.h
@@ -54,6 +54,9 @@ public:
     static Normal compute_vertex_normal(const SurfaceMesh& mesh, Vertex v);
 
     //! \brief Compute the normal vector of face \c f.
+    //! \details Normal is computed as (normalized) sum of per-corner
+    //! cross products of the two incident edges. This corresponds to
+    //! the normalized vector area in \cite alexa_2011_laplace
     static Normal compute_face_normal(const SurfaceMesh& mesh, Face f);
 
     //! \brief Compute the normal vector of the polygon corner specified by the

--- a/src/pmp/algorithms/SurfaceParameterization.cpp
+++ b/src/pmp/algorithms/SurfaceParameterization.cpp
@@ -135,6 +135,7 @@ void SurfaceParameterization::harmonic(bool use_uniform_weights)
     Eigen::SparseMatrix<double> A(n, n);
     Eigen::MatrixXd B(n, 2);
     std::vector<Eigen::Triplet<double>> triplets;
+    dvec2 b;
     double w, ww;
     Vertex v, vv;
     Edge e;
@@ -143,8 +144,7 @@ void SurfaceParameterization::harmonic(bool use_uniform_weights)
         v = free_vertices[i];
 
         // rhs row
-        B(i, 0) = 0.0;
-        B(i, 1) = 0.0;
+        b = dvec2(0.0);
 
         // lhs row
         ww = 0.0;
@@ -157,8 +157,7 @@ void SurfaceParameterization::harmonic(bool use_uniform_weights)
 
             if (mesh_.is_boundary(vv))
             {
-                B(i, 0) -= -w * tex[vv][0];
-                B(i, 1) -= -w * tex[vv][1];
+                b -= -w * static_cast<dvec2>(tex[vv]);
             }
             else
             {
@@ -166,6 +165,7 @@ void SurfaceParameterization::harmonic(bool use_uniform_weights)
             }
         }
         triplets.emplace_back(i, i, ww);
+        B.row(i) = (Eigen::Vector2d) b;
     }
 
     // build sparse matrix from triplets
@@ -183,9 +183,7 @@ void SurfaceParameterization::harmonic(bool use_uniform_weights)
         // copy solution
         for (i = 0; i < n; ++i)
         {
-            v = free_vertices[i];
-            tex[v][0] = X(i, 0);
-            tex[v][1] = X(i, 1);
+            tex[free_vertices[i]] = X.row(i);
         }
     }
 

--- a/src/pmp/visualization/SurfaceMeshGL.cpp
+++ b/src/pmp/visualization/SurfaceMeshGL.cpp
@@ -12,7 +12,6 @@
 #include <pmp/visualization/MatCapShader.h>
 #include <pmp/visualization/ColdWarmTexture.h>
 #include <pmp/algorithms/SurfaceNormals.h>
-#include <pmp/Timer.h>
 
 #include <stb_image.h>
 
@@ -251,8 +250,6 @@ void SurfaceMeshGL::set_crease_angle(Scalar ca)
 
 void SurfaceMeshGL::update_opengl_buffers()
 {
-    Timer timer; timer.start();
-
     // are buffers already initialized?
     if (!vertex_array_object_)
     {
@@ -366,18 +363,12 @@ void SurfaceMeshGL::update_opengl_buffers()
             assert(cornerVertices.size() >= 3);
 
             // tessellate face into triangles
-#if 0
-            int i0, i1, i2, nc = cornerVertices.size();
-            for (i0 = 0, i1 = 1, i2 = 2; i2 < nc; ++i1, ++i2)
-            {
-#else
             triangulate(cornerPositions, triangles);
             for (auto& t: triangles)
             {
                 int i0 = t[0];
                 int i1 = t[1];
                 int i2 = t[2];
-#endif
 
                 positionArray.push_back(cornerPositions[i0]);
                 positionArray.push_back(cornerPositions[i1]);
@@ -511,9 +502,6 @@ void SurfaceMeshGL::update_opengl_buffers()
 
     // remove vertex index property again
     remove_vertex_property(vertex_indices);
-
-    timer.stop();
-    std::cout << "Update mesh took " << timer << std::endl;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/pmp/visualization/SurfaceMeshGL.h
+++ b/src/pmp/visualization/SurfaceMeshGL.h
@@ -130,7 +130,7 @@ private: // helpers for computing triangulation of a polygon
     }
 
     // compute squared area of triangle. used for triangulate().
-    inline Scalar area(const Point& p0, const Point& p1, const Point& p2) const
+    inline Scalar area(const vec3& p0, const vec3& p1, const vec3& p2) const
     {
         return sqrnorm(cross(p1-p0, p2-p0));
     }

--- a/src/pmp/visualization/SurfaceMeshGL.h
+++ b/src/pmp/visualization/SurfaceMeshGL.h
@@ -13,6 +13,7 @@
 #include <pmp/visualization/Shader.h>
 #include <pmp/MatVec.h>
 #include <pmp/SurfaceMesh.h>
+#include <cfloat>
 
 //=============================================================================
 
@@ -98,6 +99,47 @@ public:
                       GLint min_filter = GL_LINEAR_MIPMAP_LINEAR,
                       GLint mag_filter = GL_LINEAR,
                       GLint wrap = GL_CLAMP_TO_EDGE);
+
+private: // helpers for computing triangulation of a polygon
+
+    struct Triangulation
+    {
+        Triangulation(Scalar a=FLT_MAX, int s=-1) : area(a), split(s) {}
+        Scalar area;
+        int split;
+    };
+
+    // table to hold triangulation data
+    std::vector<Triangulation> triangulation_;
+
+    // valence of currently triangulated polygon
+    unsigned int polygon_valence_;
+
+    // reserve n*n array for computing triangulation
+    void init_triangulation(unsigned int n)
+    {
+        triangulation_.clear();
+        triangulation_.resize(n*n);
+        polygon_valence_ = n;
+    }
+
+    // access triangulation array
+    Triangulation& triangulation(int start, int end)
+    {
+        return triangulation_[polygon_valence_*start + end];
+    }
+
+    // compute squared area of triangle. used for triangulate().
+    inline Scalar area(const Point& p0, const Point& p1, const Point& p2) const
+    {
+        return sqrnorm(cross(p1-p0, p2-p0));
+    }
+
+    // triangulate a polygon such that the sum of squared triangle areas is minimized.
+    // this prevents overlapping/folding triangles for non-convex polygons.
+    void triangulate(const std::vector<vec3>& points, std::vector<ivec3>& triangles);
+
+
 
 private:
     //! OpenGL buffers

--- a/src/pmp/visualization/Window.cpp
+++ b/src/pmp/visualization/Window.cpp
@@ -52,7 +52,7 @@ Window::Window(const char* title, int width, int height, bool showgui)
     
     // request core profile and OpenGL version 3.2
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_SAMPLES, 4);

--- a/tests/EigenTest.cpp
+++ b/tests/EigenTest.cpp
@@ -1,0 +1,83 @@
+//=============================================================================
+// Copyright (C) 2017-2019 The pmp-library developers
+//
+// This file is part of the Polygon Mesh Processing Library.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+//
+// SPDX-License-Identifier: MIT-with-employer-disclaimer
+//=============================================================================
+
+#include "gtest/gtest.h"
+
+#include <pmp/SurfaceMesh.h>
+#include <pmp/MatVec.h>
+#include <vector>
+
+using namespace pmp;
+
+class EigenTest: public ::testing::Test
+{
+public:
+
+};
+
+TEST_F(EigenTest, construct_from_eigen)
+{
+    {
+        Eigen::Vector2f eigenVec(1.0f, 2.0f);
+        vec2 pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2.0f);
+    }
+    {
+        Eigen::Vector3d eigenVec(1.0, 2.0, 3.0);
+        dvec3 pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2.0);
+    }
+    {
+        Eigen::Vector4i eigenVec(1, 2, 3, 4);
+        ivec4 pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2);
+    }
+}
+
+TEST_F(EigenTest, assignment_from_eigen)
+{
+    {
+        Eigen::Vector2f eigenVec(1.0f, 2.0f);
+        vec2 pmpVec;
+        pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2.0f);
+    }
+    {
+        Eigen::Vector3d eigenVec(1.0, 2.0, 3.0);
+        dvec3 pmpVec;
+        pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2.0);
+    }
+    {
+        Eigen::Vector4i eigenVec(1, 2, 3, 4);
+        ivec4 pmpVec;
+        pmpVec = eigenVec;
+        EXPECT_EQ(pmpVec[1], 2);
+    }
+}
+
+TEST_F(EigenTest, cast_to_eigen)
+{
+    {
+        vec2 pmpVec(1.0f, 2.0f);
+        Eigen::Vector2f eigenVec = static_cast<Eigen::Vector2f>(pmpVec);
+        EXPECT_EQ(eigenVec[1], 2.0f);
+    }
+    {
+        dvec3 pmpVec(1.0, 2.0, 3.0);
+        Eigen::Vector3f eigenVec = static_cast<Eigen::Vector3f>(pmpVec);
+        EXPECT_EQ(eigenVec[1], 2.0);
+    }
+    {
+        ivec4 pmpVec(1, 2, 3, 4);
+        Eigen::Vector4i eigenVec = static_cast<Eigen::Vector4i>(pmpVec);
+        EXPECT_EQ(eigenVec[1], 2);
+    }
+}
+

--- a/tests/EigenTest.cpp
+++ b/tests/EigenTest.cpp
@@ -38,6 +38,19 @@ TEST_F(EigenTest, construct_from_eigen)
         ivec4 pmpVec = eigenVec;
         EXPECT_EQ(pmpVec[1], 2);
     }
+
+    {
+        Eigen::Matrix2d eigenMat; 
+        eigenMat << 1.0, 2.0, 3.0, 4.0;
+        mat2 pmpMat = eigenMat;
+        EXPECT_EQ(pmpMat(1,1), 4.0);
+    }
+    {
+        Eigen::MatrixXd eigenMat(2,2); 
+        eigenMat << 1.0, 2.0, 3.0, 4.0;
+        mat2 pmpMat;
+        pmpMat = eigenMat;
+    }
 }
 
 TEST_F(EigenTest, assignment_from_eigen)
@@ -60,6 +73,19 @@ TEST_F(EigenTest, assignment_from_eigen)
         pmpVec = eigenVec;
         EXPECT_EQ(pmpVec[1], 2);
     }
+
+    {
+        Eigen::Matrix2d eigenMat; 
+        eigenMat << 1.0, 2.0, 3.0, 4.0;
+        mat2 pmpMat; pmpMat = eigenMat;
+        EXPECT_EQ(pmpMat(1,1), 4.0);
+    }
+    {
+        Eigen::MatrixXd eigenMat(2,2); 
+        eigenMat << 1.0, 2.0, 3.0, 4.0;
+        mat2 pmpMat = eigenMat;
+        EXPECT_EQ(pmpMat(1,1), 4.0);
+    }
 }
 
 TEST_F(EigenTest, cast_to_eigen)
@@ -78,6 +104,14 @@ TEST_F(EigenTest, cast_to_eigen)
         ivec4 pmpVec(1, 2, 3, 4);
         Eigen::Vector4i eigenVec = static_cast<Eigen::Vector4i>(pmpVec);
         EXPECT_EQ(eigenVec[1], 2);
+    }
+
+    {
+        dmat3 pmpMat{1.0, 2.0, 3.0, 
+                     4.0, 5.0, 6.0, 
+                     7.0, 8.0, 9.0};
+        Eigen::Matrix3f eigenMat = static_cast<Eigen::Matrix3f>(pmpMat);
+        EXPECT_EQ(eigenMat(1,1), 5.0);
     }
 }
 


### PR DESCRIPTION
This pull request improves the interoperability with Eigen by adding assignment from and cast to Eigen matrices/vectors. The nicer syntax has been integrated into the algorithms that solve linear system using Eigen.

The PR also adds a better tessellation of general polygons into triangles for OpenGL rendering, such that  overlapping sub-triangles are avoided. This comes at a certain price in terms of performance, but the previous results was just wrong for non-convex elements. I added a test file in `external/pmp-data/off/L.off`.

Determining front and backfacing pixels does not work reliably for Phong shading, such that front/back color are assigned erroneously. Flat shading (crease angle=0) works, since there the vector area is used as normal vector. This can probably be fixed by circumventing Apple's driver bug for gl_FrontFacing.