### PR TITLE
Add post-increment iterators

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -261,6 +261,14 @@ public:
             return *this;
         }
 
+        //! post-increment iterator
+        VertexIterator operator++(int)
+        {
+            VertexIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
         //! pre-decrement iterator
         VertexIterator& operator--()
         {
@@ -317,6 +325,14 @@ public:
                    mesh_->is_deleted(handle_))
                 ++handle_.idx_;
             return *this;
+        }
+
+        //! post-increment iterator
+        HalfedgeIterator operator++(int)
+        {
+            HalfedgeIterator tmp = *this;
+            ++(*this);
+            return tmp;
         }
 
         //! pre-decrement iterator
@@ -376,6 +392,14 @@ public:
             return *this;
         }
 
+        //! post-increment iterator
+        EdgeIterator operator++(int)
+        {
+            EdgeIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
         //! pre-decrement iterator
         EdgeIterator& operator--()
         {
@@ -431,6 +455,14 @@ public:
                    mesh_->is_deleted(handle_))
                 ++handle_.idx_;
             return *this;
+        }
+
+        //! post-increment iterator
+        FaceIterator operator++(int)
+        {
+            FaceIterator tmp = *this;
+            ++(*this);
+            return tmp;
         }
 
         //! pre-decrement iterator


### PR DESCRIPTION
# Description

Add post-increment iterators

# Motivation

Otherwise concept checking will fail when using a `SurfaceMesh` with a Boost Graph Library (BGL) algorithm.

# Benefits

That with a little bit of glue provided by CGAL, you can run any graph algorithm of the BGL directly on a `SurfaceMesh`.

# Drawbacks

That a user uses the post-increment, not knowing that he better used the pre-increment.  You might not document the post-increment?

# Applicable Issues

Let me know if you want me to create an issue.
