### PR TITLE
Add low level functions for adding a vertex/edge/face

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1785,6 +1785,8 @@ private:
     };
 
     //!@}
+
+public:
     //! \name Allocate new elements
     //!@{
 
@@ -1800,6 +1802,26 @@ private:
         }
         vprops_.push_back();
         return Vertex(vertices_size() - 1);
+    }
+
+    //! allocate a new edge, resize edge and halfedge properties accordingly.
+    Halfedge new_edge()
+    {
+        if (halfedges_size() == PMP_MAX_INDEX - 1)
+        {
+            std::cerr << "new_edge: cannot allocate edge, max. index reached"
+                      << std::endl;
+            return Halfedge();
+        }
+
+        eprops_.push_back();
+        hprops_.push_back();
+        hprops_.push_back();
+
+        Halfedge h0(halfedges_size() - 2);
+        Halfedge h1(halfedges_size() - 1);
+
+        return h0;
     }
 
     //! allocate a new edge, resize edge and halfedge properties accordingly.
@@ -1842,6 +1864,8 @@ private:
     }
 
     //!@}
+
+private:
     //! \name Helper functions
     //!@{
 


### PR DESCRIPTION
# Description

This PR enables to build a `SurfaceMesh` with low level functions by adding a vertex, edge, or face without an initial point or incident vertices.

I make the section with private functions `new_vertex()` etc  public.

# Motivation

These functions are needed in order to use CGAL functions that add entities for example when calling a [hole filling function](https://github.com/CGAL/cgal/blob/20bf436b50412a81394ba7085f932c83c2213b33/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_PMP.cpp).

# Benefits
This PR completes the low level functions. My guess why they are not provided  is, that you want to avoid that one can produce a mesh that is not valid, but on the other hand as soon as I use one of the `set..()` low level functions the  mesh may be no longer valid. 
Btw, I am wondering if the function `adjust_outgoing_halfedge(..)` must not also be made public.

# Drawbacks

I can't see one.  

# Applicable Issues

Let me know if you want me to file an issue.
