### PR TITLE
fix 1 degree clamp, and fix voronoi_area_barycentric area calculation

### DIFF
--- a/src/pmp/algorithms/BarycentricCoordinates.h
+++ b/src/pmp/algorithms/BarycentricCoordinates.h
@@ -7,6 +7,8 @@
 
 namespace pmp {
 
+//! \ingroup algorithms
+//! \brief Calculate barycentric coordinates of point p in triangle (uvw).
 template <typename Scalar>
 const Vector<Scalar, 3> barycentric_coordinates(const Vector<Scalar, 3>& p,
                                                 const Vector<Scalar, 3>& u,

--- a/src/pmp/algorithms/DifferentialGeometry.cpp
+++ b/src/pmp/algorithms/DifferentialGeometry.cpp
@@ -204,7 +204,7 @@ double voronoi_area_barycentric(const SurfaceMesh& mesh, Vertex v)
             pr = mesh.position(mesh.to_vertex(h1));
             pr -= p;
 
-            area += norm(cross(pq, pr)) / 3.0;
+            area += norm(cross(pq, pr)) / 6.0;
         }
     }
 

--- a/src/pmp/algorithms/DifferentialGeometry.h
+++ b/src/pmp/algorithms/DifferentialGeometry.h
@@ -14,14 +14,14 @@ namespace pmp {
 //! clamp cotangent values as if angles are in [1, 179]
 inline double clamp_cot(const double v)
 {
-    const double bound = 19.1; // 3 degrees
+    const double bound = 57.3; // 1 degrees
     return (v < -bound ? -bound : (v > bound ? bound : v));
 }
 
 //! clamp cosine values as if angles are in [1, 179]
 inline double clamp_cos(const double v)
 {
-    const double bound = 0.9986; // 3 degrees
+    const double bound = 0.99985; // 1 degrees
     return (v < -bound ? -bound : (v > bound ? bound : v));
 }
 

--- a/src/pmp/algorithms/SurfaceSmoothing.cpp
+++ b/src/pmp/algorithms/SurfaceSmoothing.cpp
@@ -103,7 +103,14 @@ void SurfaceSmoothing::explicit_smoothing(unsigned int iters,
                     w += eweight[e];
                 }
 
-                l /= w;
+                if (1.0 + w == 1.0)
+                {
+                    l = Point(0, 0, 0);
+                }
+                else
+                {
+                    l /= w;
+                }
             }
 
             laplace[v] = l;


### PR DESCRIPTION
# Description

fix 1 degree clamp, and fix voronoi_area_barycentric area calculation

## 1. fix 1 degree clamp

the comment of function `clamp_cot` and `clamp_cos` is like clamp to [1, 179], see below 

```c++
//! clamp cotangent values as if angles are in [1, 179]
inline double clamp_cot(const double v)
{
    const double bound = 57.3; // 1 degrees
    return (v < -bound ? -bound : (v > bound ? bound : v));
}

//! clamp cosine values as if angles are in [1, 179]
inline double clamp_cos(const double v)
{
    const double bound = 0.99985; // 1 degrees
    return (v < -bound ? -bound : (v > bound ? bound : v));
}
```

and in the usage the comment is : 

```c++
// function: voronoi_area
                // clamp cot(angle) by clamping angle to [1,179]
                area += 0.125 * (sqrnorm(pr) * clamp_cot(cotq) +
                                 sqrnorm(pq) * clamp_cot(cotr));
```

so, the source code should be clamped to 1 degree. `cot(1) = 57.3; cos(1) = 0.99985`

## 2.  fix voronoi_area_barycentric area calculation

The triangle area equals `norm(cross(pq, pr))/2`. So, the area of one trianlge contributing to the voronoi_area_barycentric is `norm(cross(pq, pr))/6.0`

