### PR TITLE
fix 3 degree comment, and fix voronoi_area_barycentric area calculation

### DIFF
--- a/src/pmp/algorithms/DifferentialGeometry.cpp
+++ b/src/pmp/algorithms/DifferentialGeometry.cpp
@@ -193,7 +193,7 @@ double voronoi_area(const SurfaceMesh& mesh, Vertex v)
                 cotq = dotq / triArea;
                 cotr = dotr / triArea;
 
-                // clamp cot(angle) by clamping angle to [1,179]
+                // clamp cot(angle) by clamping angle to [3, 177]
                 area += 0.125 * (sqrnorm(pr) * clamp_cot(cotq) +
                                  sqrnorm(pq) * clamp_cot(cotr));
             }

--- a/src/pmp/algorithms/DifferentialGeometry.cpp
+++ b/src/pmp/algorithms/DifferentialGeometry.cpp
@@ -230,7 +230,7 @@ double voronoi_area_barycentric(const SurfaceMesh& mesh, Vertex v)
             pr = mesh.position(mesh.to_vertex(h1));
             pr -= p;
 
-            area += norm(cross(pq, pr)) / 3.0;
+            area += norm(cross(pq, pr)) / 6.0;
         }
     }
 

--- a/src/pmp/algorithms/DifferentialGeometry.h
+++ b/src/pmp/algorithms/DifferentialGeometry.h
@@ -11,14 +11,14 @@ namespace pmp {
 //! \addtogroup algorithms
 //! @{
 
-//! clamp cotangent values as if angles are in [1, 179]
+//! clamp cotangent values as if angles are in [3, 177]
 inline double clamp_cot(const double v)
 {
     const double bound = 19.1; // 3 degrees
     return (v < -bound ? -bound : (v > bound ? bound : v));
 }
 
-//! clamp cosine values as if angles are in [1, 179]
+//! clamp cosine values as if angles are in [3, 177]
 inline double clamp_cos(const double v)
 {
     const double bound = 0.9986; // 3 degrees

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -62,7 +62,7 @@ TEST_F(DifferentialGeometryTest, voronoi_area_barycentric)
 {
     one_ring();
     Scalar area = voronoi_area_barycentric(mesh, v0);
-    EXPECT_FLOAT_EQ(area, 0.049180791);
+    EXPECT_FLOAT_EQ(area, 0.024590395);
 }
 
 TEST_F(DifferentialGeometryTest, laplace)


### PR DESCRIPTION
# Description

fix 3 degree comment, and fix voronoi_area_barycentric area calculation

# Motivation

The comment and the source code of clamp is inconsistent. And the voronoi_area_barycentric  calculation is error.
