### PR TITLE
Test refactoring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE --parallel
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build/tests
+      working-directory: ${{runner.workspace}}/build
       shell: bash
-      # run: ctest -C $BUILD_TYPE
-      run: ./gtest_runner
+      run: ctest -C $BUILD_TYPE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE --parallel
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{runner.workspace}}/build/tests
       shell: bash
-      run: ctest -C $BUILD_TYPE
+      # run: ctest -C $BUILD_TYPE
+      run: ./gtest_runner

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -35,8 +35,6 @@ public:
     void one_ring()
     {
         mesh = vertex_onering();
-        EXPECT_EQ(mesh.n_vertices(), size_t(7));
-        EXPECT_EQ(mesh.n_faces(), size_t(6));
         central_vertex = Vertex(3);             // the central vertex
         mesh.position(central_vertex)[2] = 0.1; // lift central vertex
     }

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -6,6 +6,8 @@
 
 #include <pmp/SurfaceMesh.h>
 #include <pmp/algorithms/DifferentialGeometry.h>
+#include <pmp/algorithms/SurfaceFactory.h>
+
 #include <vector>
 
 using namespace pmp;
@@ -14,6 +16,8 @@ class DifferentialGeometryTest : public ::testing::Test
 {
 public:
     SurfaceMesh mesh;
+    static SurfaceMesh sphere;
+
     Vertex v0, v1, v2, v3;
     Face f0;
 
@@ -34,14 +38,9 @@ public:
         auto points = mesh.get_vertex_property<Point>("v:point");
         points[v0][2] = 0.1; // lift central vertex
     }
-
-    void unit_sphere()
-    {
-        ASSERT_TRUE(mesh.read("pmp-data/off/sphere.off"));
-        EXPECT_EQ(mesh.n_vertices(), size_t(16070));
-        EXPECT_EQ(mesh.n_faces(), size_t(32136));
-    }
 };
+
+SurfaceMesh DifferentialGeometryTest::sphere = SurfaceFactory::icosphere(5);
 
 TEST_F(DifferentialGeometryTest, triangle_areaPoints)
 {
@@ -84,31 +83,18 @@ TEST_F(DifferentialGeometryTest, vertex_curvature)
 
 TEST_F(DifferentialGeometryTest, surface_area)
 {
-    unit_sphere();
-    auto area = surface_area(mesh);
-
-#ifdef PMP_SCALAR_TYPE_64
-    EXPECT_FLOAT_EQ(area, 12.563956);
-#else
-    EXPECT_FLOAT_EQ(area, 12.564044);
-#endif
+    auto area = surface_area(sphere);
+    EXPECT_NEAR(area, 12.57, 1.0e-2);
 }
 
 TEST_F(DifferentialGeometryTest, volume)
 {
-    unit_sphere();
-    auto v = volume(mesh);
-
-#ifdef PMP_SCALAR_TYPE_64
-    EXPECT_FLOAT_EQ(v, 4.18733706);
-#else
-    EXPECT_FLOAT_EQ(v, 4.18731928);
-#endif
+    auto v = volume(sphere);
+    EXPECT_NEAR(v, 4.18, 1.0e-2);
 }
 
 TEST_F(DifferentialGeometryTest, centroid)
 {
-    unit_sphere();
-    auto center = centroid(mesh);
+    auto center = centroid(sphere);
     EXPECT_LT(norm(center), 1e-5);
 }

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -7,6 +7,8 @@
 #include <pmp/algorithms/DifferentialGeometry.h>
 #include <pmp/algorithms/SurfaceFactory.h>
 
+#include "Helpers.h"
+
 #include <vector>
 
 using namespace pmp;
@@ -20,6 +22,8 @@ public:
     Vertex v0, v1, v2, v3;
     Face f0;
 
+    Vertex central_vertex;
+
     void add_triangle()
     {
         v0 = mesh.add_vertex(Point(0, 0, 0));
@@ -30,12 +34,11 @@ public:
 
     void one_ring()
     {
-        ASSERT_TRUE(mesh.read("pmp-data/off/vertex_onering.off"));
+        mesh = vertex_onering();
         EXPECT_EQ(mesh.n_vertices(), size_t(7));
         EXPECT_EQ(mesh.n_faces(), size_t(6));
-        v0 = Vertex(3); // the central vertex
-        auto points = mesh.get_vertex_property<Point>("v:point");
-        points[v0][2] = 0.1; // lift central vertex
+        central_vertex = Vertex(3);             // the central vertex
+        mesh.position(central_vertex)[2] = 0.1; // lift central vertex
     }
 };
 
@@ -59,21 +62,21 @@ TEST_F(DifferentialGeometryTest, triangle_areaFace)
 TEST_F(DifferentialGeometryTest, voronoi_area_barycentric)
 {
     one_ring();
-    Scalar area = voronoi_area_barycentric(mesh, v0);
+    Scalar area = voronoi_area_barycentric(mesh, central_vertex);
     EXPECT_FLOAT_EQ(area, 0.024590395);
 }
 
 TEST_F(DifferentialGeometryTest, laplace)
 {
     one_ring();
-    auto lv = laplace(mesh, v0);
+    auto lv = laplace(mesh, central_vertex);
     EXPECT_GT(norm(lv), 0);
 }
 
 TEST_F(DifferentialGeometryTest, vertex_curvature)
 {
     one_ring();
-    auto vcurv = vertex_curvature(mesh, v0);
+    auto vcurv = vertex_curvature(mesh, central_vertex);
     EXPECT_FLOAT_EQ(vcurv.mean, 6.1538467);
     EXPECT_FLOAT_EQ(vcurv.gauss, 50.860939);
     EXPECT_FLOAT_EQ(vcurv.max, 6.1538467);

--- a/tests/DifferentialGeometryTest.cpp
+++ b/tests/DifferentialGeometryTest.cpp
@@ -42,7 +42,7 @@ public:
 
 SurfaceMesh DifferentialGeometryTest::sphere = SurfaceFactory::icosphere(5);
 
-TEST_F(DifferentialGeometryTest, triangle_areaPoints)
+TEST_F(DifferentialGeometryTest, triangle_area_points)
 {
     add_triangle();
     Scalar area =
@@ -50,7 +50,7 @@ TEST_F(DifferentialGeometryTest, triangle_areaPoints)
     EXPECT_EQ(area, 0.5);
 }
 
-TEST_F(DifferentialGeometryTest, triangle_areaFace)
+TEST_F(DifferentialGeometryTest, triangle_area_face)
 {
     add_triangle();
     Scalar area = triangle_area(mesh, f0);

--- a/tests/DistancePointTriangleTest.cpp
+++ b/tests/DistancePointTriangleTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -60,7 +60,7 @@ SurfaceMesh edge_onering()
     mesh.add_triangle(v8, v4, v5);
     mesh.add_triangle(v9, v8, v5);
     mesh.add_triangle(v9, v5, v6);
-    mesh.write("onering.off");
+
     return mesh;
 }
 

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -3,6 +3,9 @@
 
 #include "Helpers.h"
 
+#include "pmp/algorithms/SurfaceFactory.h"
+#include "pmp/algorithms/SurfaceRemeshing.h"
+
 namespace pmp {
 
 SurfaceMesh vertex_onering()
@@ -27,4 +30,22 @@ SurfaceMesh vertex_onering()
     return mesh;
 }
 
+SurfaceMesh hemisphere()
+{
+    // generate quad sphere mesh and triangulate it
+    auto mesh = SurfaceFactory::quad_sphere(5);
+    mesh.triangulate();
+
+    // delete lower half
+    for (auto v : mesh.vertices())
+        if (mesh.position(v)[1] < -0.01)
+            mesh.delete_vertex(v);
+    mesh.garbage_collection();
+
+    // remesh to get nice but irregular triangulation
+    SurfaceRemeshing(mesh).uniform_remeshing(0.05);
+
+    return mesh;
 }
+
+} // namespace pmp

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -35,6 +35,35 @@ SurfaceMesh vertex_onering()
     return mesh;
 }
 
+SurfaceMesh edge_onering()
+{
+    SurfaceMesh mesh;
+
+    auto v0 = mesh.add_vertex(Point(0.5999997854, 0.5196152329, 0.0000000000));
+    auto v1 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, 0.0000000000));
+    auto v2 = mesh.add_vertex(Point(0.2999998033, 0.5196152329, 0.0000000000));
+    auto v3 = mesh.add_vertex(Point(0.6749998331, 0.3897114396, 0.0000000000));
+    auto v4 = mesh.add_vertex(Point(0.5249998569, 0.3897114396, 0.0000000000));
+    auto v5 = mesh.add_vertex(Point(0.3749998510, 0.3897114396, 0.0000000000));
+    auto v6 = mesh.add_vertex(Point(0.2249998450, 0.3897114396, 0.0000000000));
+    auto v7 = mesh.add_vertex(Point(0.5999999046, 0.2598076165, 0.0000000000));
+    auto v8 = mesh.add_vertex(Point(0.4499999285, 0.2598076165, 0.0000000000));
+    auto v9 = mesh.add_vertex(Point(0.2999999225, 0.2598076165, 0.0000000000));
+
+    mesh.add_triangle(v4, v0, v1);
+    mesh.add_triangle(v4, v3, v0);
+    mesh.add_triangle(v5, v1, v2);
+    mesh.add_triangle(v5, v4, v1);
+    mesh.add_triangle(v6, v5, v2);
+    mesh.add_triangle(v7, v3, v4);
+    mesh.add_triangle(v8, v7, v4);
+    mesh.add_triangle(v8, v4, v5);
+    mesh.add_triangle(v9, v8, v5);
+    mesh.add_triangle(v9, v5, v6);
+    mesh.write("onering.off");
+    return mesh;
+}
+
 SurfaceMesh hemisphere()
 {
     if (hemisphere_mesh.is_empty())

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -5,10 +5,13 @@
 
 #include "pmp/algorithms/SurfaceFactory.h"
 #include "pmp/algorithms/SurfaceRemeshing.h"
+#include "pmp/algorithms/SurfaceFeatures.h"
+#include "pmp/algorithms/SurfaceSubdivision.h"
 
 namespace pmp {
 
 static SurfaceMesh hemisphere_mesh;
+static SurfaceMesh icosahedron_mesh;
 
 SurfaceMesh vertex_onering()
 {
@@ -53,6 +56,27 @@ SurfaceMesh hemisphere()
         SurfaceRemeshing(mesh).uniform_remeshing(0.1);
     }
     return hemisphere_mesh;
+}
+
+SurfaceMesh subdivided_icosahedron()
+{
+    if (icosahedron_mesh.is_empty())
+    {
+        // use ref for brevity
+        auto& mesh = icosahedron_mesh;
+        mesh = SurfaceFactory::icosahedron();
+
+        // select all edges as features
+        SurfaceFeatures sf(mesh);
+        sf.detect_angle(25);
+
+        // feature-preserving subdivision
+        SurfaceSubdivision subdiv(mesh);
+        subdiv.loop();
+        subdiv.loop();
+        subdiv.loop();
+    }
+    return icosahedron_mesh;
 }
 
 } // namespace pmp

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -3,11 +3,10 @@
 
 #include "Helpers.h"
 
-pmp::SurfaceMesh vertex_onering()
-{
-    using pmp::Point;
-    using pmp::SurfaceMesh;
+namespace pmp {
 
+SurfaceMesh vertex_onering()
+{
     SurfaceMesh mesh;
 
     auto v0 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, 0.0000000000));
@@ -26,4 +25,6 @@ pmp::SurfaceMesh vertex_onering()
     mesh.add_triangle(v6, v3, v4);
 
     return mesh;
+}
+
 }

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -8,6 +8,8 @@
 
 namespace pmp {
 
+static SurfaceMesh hemisphere_mesh;
+
 SurfaceMesh vertex_onering()
 {
     SurfaceMesh mesh;
@@ -32,20 +34,25 @@ SurfaceMesh vertex_onering()
 
 SurfaceMesh hemisphere()
 {
-    // generate quad sphere mesh and triangulate it
-    auto mesh = SurfaceFactory::quad_sphere(5);
-    mesh.triangulate();
+    if (hemisphere_mesh.is_empty())
+    {
+        // use ref for brevity
+        auto& mesh = hemisphere_mesh;
 
-    // delete lower half
-    for (auto v : mesh.vertices())
-        if (mesh.position(v)[1] < -0.01)
-            mesh.delete_vertex(v);
-    mesh.garbage_collection();
+        // generate quad sphere mesh and triangulate it
+        mesh = SurfaceFactory::quad_sphere(3);
+        mesh.triangulate();
 
-    // remesh to get nice but irregular triangulation
-    SurfaceRemeshing(mesh).uniform_remeshing(0.05);
+        // delete lower half
+        for (auto v : mesh.vertices())
+            if (mesh.position(v)[1] < -0.01)
+                mesh.delete_vertex(v);
+        mesh.garbage_collection();
 
-    return mesh;
+        // remesh to get nice but irregular triangulation
+        SurfaceRemeshing(mesh).uniform_remeshing(0.1);
+    }
+    return hemisphere_mesh;
 }
 
 } // namespace pmp

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -1,0 +1,29 @@
+// Copyright 2021 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#include "Helpers.h"
+
+pmp::SurfaceMesh vertex_onering()
+{
+    using pmp::Point;
+    using pmp::SurfaceMesh;
+
+    SurfaceMesh mesh;
+
+    auto v0 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, 0.0000000000));
+    auto v1 = mesh.add_vertex(Point(0.2999998033, 0.5196152329, 0.0000000000));
+    auto v2 = mesh.add_vertex(Point(0.5249998569, 0.3897114396, 0.0000000000));
+    auto v3 = mesh.add_vertex(Point(0.3749998510, 0.3897114396, 0.0000000000));
+    auto v4 = mesh.add_vertex(Point(0.2249998450, 0.3897114396, 0.0000000000));
+    auto v5 = mesh.add_vertex(Point(0.4499999285, 0.2598076165, 0.0000000000));
+    auto v6 = mesh.add_vertex(Point(0.2999999225, 0.2598076165, 0.0000000000));
+
+    mesh.add_triangle(v3, v0, v1);
+    mesh.add_triangle(v3, v2, v0);
+    mesh.add_triangle(v4, v3, v1);
+    mesh.add_triangle(v5, v2, v3);
+    mesh.add_triangle(v6, v5, v3);
+    mesh.add_triangle(v6, v3, v4);
+
+    return mesh;
+}

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -1,32 +1,9 @@
 // Copyright 2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
+#pragma once
+
 #include <pmp/SurfaceMesh.h>
 
 // generate triangle fan of six triangles around center vertex
-pmp::SurfaceMesh vertex_onering()
-{
-    using pmp::Point;
-    using pmp::SurfaceMesh;
-
-    SurfaceMesh mesh;
-
-    auto v0 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, 0.0000000000));
-    auto v1 = mesh.add_vertex(Point(0.2999998033, 0.5196152329, 0.0000000000));
-    auto v2 = mesh.add_vertex(Point(0.5249998569, 0.3897114396, 0.0000000000));
-    auto v3 = mesh.add_vertex(Point(0.3749998510, 0.3897114396, 0.0000000000));
-    auto v4 = mesh.add_vertex(Point(0.2249998450, 0.3897114396, 0.0000000000));
-    auto v5 = mesh.add_vertex(Point(0.4499999285, 0.2598076165, 0.0000000000));
-    auto v6 = mesh.add_vertex(Point(0.2999999225, 0.2598076165, 0.0000000000));
-
-    mesh.add_triangle(v3, v0, v1);
-    mesh.add_triangle(v3, v2, v0);
-    mesh.add_triangle(v4, v3, v1);
-    mesh.add_triangle(v5, v2, v3);
-    mesh.add_triangle(v6, v5, v3);
-    mesh.add_triangle(v6, v3, v4);
-
-    mesh.write("onering_new.off");
-
-    return mesh;
-}
+pmp::SurfaceMesh vertex_onering();

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -13,4 +13,9 @@ SurfaceMesh vertex_onering();
 // generate hemisphere mesh; cuts lower half of unit sphere
 SurfaceMesh hemisphere();
 
+// generate subdivided icosahedron
+// based on Loop subdivision
+// original icosahedron edges are marked as feature edges
+SurfaceMesh subdivided_icosahedron();
+
 } // namespace pmp

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -10,4 +10,7 @@ namespace pmp {
 // generate triangle fan of six triangles around center vertex
 SurfaceMesh vertex_onering();
 
+// generate hemisphere mesh; cuts lower half of unit sphere
+SurfaceMesh hemisphere();
+
 } // namespace pmp

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -10,6 +10,9 @@ namespace pmp {
 // generate triangle fan of six triangles around center vertex
 SurfaceMesh vertex_onering();
 
+// generate onering around an edge
+SurfaceMesh edge_onering();
+
 // generate hemisphere mesh; cuts lower half of unit sphere
 SurfaceMesh hemisphere();
 

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -5,5 +5,9 @@
 
 #include <pmp/SurfaceMesh.h>
 
+namespace pmp {
+
 // generate triangle fan of six triangles around center vertex
-pmp::SurfaceMesh vertex_onering();
+SurfaceMesh vertex_onering();
+
+} // namespace pmp

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -1,0 +1,32 @@
+// Copyright 2021 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#include <pmp/SurfaceMesh.h>
+
+// generate triangle fan of six triangles around center vertex
+pmp::SurfaceMesh vertex_onering()
+{
+    using pmp::Point;
+    using pmp::SurfaceMesh;
+
+    SurfaceMesh mesh;
+
+    auto v0 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, 0.0000000000));
+    auto v1 = mesh.add_vertex(Point(0.2999998033, 0.5196152329, 0.0000000000));
+    auto v2 = mesh.add_vertex(Point(0.5249998569, 0.3897114396, 0.0000000000));
+    auto v3 = mesh.add_vertex(Point(0.3749998510, 0.3897114396, 0.0000000000));
+    auto v4 = mesh.add_vertex(Point(0.2249998450, 0.3897114396, 0.0000000000));
+    auto v5 = mesh.add_vertex(Point(0.4499999285, 0.2598076165, 0.0000000000));
+    auto v6 = mesh.add_vertex(Point(0.2999999225, 0.2598076165, 0.0000000000));
+
+    mesh.add_triangle(v3, v0, v1);
+    mesh.add_triangle(v3, v2, v0);
+    mesh.add_triangle(v4, v3, v1);
+    mesh.add_triangle(v5, v2, v3);
+    mesh.add_triangle(v6, v5, v3);
+    mesh.add_triangle(v6, v3, v4);
+
+    mesh.write("onering_new.off");
+
+    return mesh;
+}

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1,0 +1,15 @@
+// Copyright 2021 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#include "gtest/gtest.h"
+
+#include "Helpers.h"
+
+using namespace pmp;
+
+TEST(Helpers, vertex_onering)
+{
+    auto mesh = vertex_onering();
+    EXPECT_EQ(mesh.n_vertices(), size_t(7));
+    EXPECT_EQ(mesh.n_faces(), size_t(6));
+}

--- a/tests/SurfaceCurvatureTest.cpp
+++ b/tests/SurfaceCurvatureTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceCurvatureTest.cpp
+++ b/tests/SurfaceCurvatureTest.cpp
@@ -3,7 +3,8 @@
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceCurvature.h>
+#include "pmp/algorithms/SurfaceCurvature.h"
+#include "pmp/algorithms/SurfaceFactory.h"
 
 using namespace pmp;
 
@@ -12,7 +13,7 @@ class SurfaceCurvatureTest : public ::testing::Test
 public:
     SurfaceCurvatureTest()
     {
-        EXPECT_TRUE(mesh.read("pmp-data/off/hemisphere.off"));
+        mesh = SurfaceFactory::icosphere(5);
         curvature = new SurfaceCurvature(mesh);
         curvature->analyze(1);
     }
@@ -42,21 +43,12 @@ TEST_F(SurfaceCurvatureTest, curvature)
         gmax = std::max(gmax, curvature->gauss_curvature(v));
     }
 
-#ifdef PMP_SCALAR_TYPE_64
-    EXPECT_FLOAT_EQ(kmin, 0.50240165);
-    EXPECT_FLOAT_EQ(kmax, 1.0002906);
-    EXPECT_FLOAT_EQ(mmin, 0.50240165);
-    EXPECT_FLOAT_EQ(mmax, 1.0002906);
-    EXPECT_FLOAT_EQ(gmin, 0.2524074);
-    EXPECT_FLOAT_EQ(gmax, 1.0005813);
-#else
-    EXPECT_FLOAT_EQ(kmin, 0.50240648);
-    EXPECT_FLOAT_EQ(kmax, 1.0003014);
-    EXPECT_FLOAT_EQ(mmin, 0.50240648);
-    EXPECT_FLOAT_EQ(mmax, 1.0003014);
-    EXPECT_FLOAT_EQ(gmin, 0.25241226);
-    EXPECT_FLOAT_EQ(gmax, 1.0006028);
-#endif
+    EXPECT_NEAR(kmin, 1.0, 0.02);
+    EXPECT_NEAR(kmax, 1.0, 0.02);
+    EXPECT_NEAR(mmin, 1.0, 0.02);
+    EXPECT_NEAR(mmax, 1.0, 0.02);
+    EXPECT_NEAR(gmin, 1.0, 0.02);
+    EXPECT_NEAR(gmax, 1.0, 0.02);
 }
 
 TEST_F(SurfaceCurvatureTest, mean_curvature_to_texture_coordinates)

--- a/tests/SurfaceFairingTest.cpp
+++ b/tests/SurfaceFairingTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceFairingTest.cpp
+++ b/tests/SurfaceFairingTest.cpp
@@ -1,55 +1,34 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceFairing.h>
+#include "pmp/algorithms/SurfaceFairing.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceFairingTest : public ::testing::Test
+TEST(SurfaceFairingTest, fairing)
 {
-public:
-    SurfaceFairingTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/icosahedron_subdiv.off"));
-    }
-    SurfaceMesh mesh;
-};
-
-TEST_F(SurfaceFairingTest, fairing)
-{
-    mesh.read("pmp-data/off/hemisphere.off");
-    auto bbz = mesh.bounds().max()[2];
+    auto mesh = hemisphere();
+    auto bbz = mesh.bounds().max()[1];
     SurfaceFairing sf(mesh);
     sf.fair();
-    auto bbs = mesh.bounds().max()[2];
+    auto bbs = mesh.bounds().max()[1];
     EXPECT_LT(bbs, bbz);
 }
 
-TEST_F(SurfaceFairingTest, fairing_selected)
+TEST(SurfaceFairingTest, fairing_selected)
 {
-    mesh.read("pmp-data/off/sphere_low.off");
+    SurfaceMesh mesh = hemisphere();
     auto bb = mesh.bounds();
-    Scalar yrange = bb.max()[1] - bb.min()[1];
-    auto vselected = mesh.vertex_property<bool>("v:selected", false);
+
+    // select top vertices for fairing
+    auto selected = mesh.vertex_property<bool>("v:selected");
     for (auto v : mesh.vertices())
-    {
-        auto p = mesh.position(v);
-        if (p[1] >= (bb.max()[1] - 0.2 * yrange))
-        {
-            vselected[v] = false;
-        }
-        else if (p[1] < (bb.max()[1] - 0.2 * yrange) &&
-                 p[1] > (bb.max()[1] - 0.8 * yrange))
-        {
-            vselected[v] = true;
-        }
-        else
-        {
-            vselected[v] = false;
-        }
-    }
+        if (mesh.position(v)[1] > 0.5)
+            selected[v] = true;
+
     SurfaceFairing sf(mesh);
     sf.fair();
     auto bb2 = mesh.bounds();

--- a/tests/SurfaceFeaturesTest.cpp
+++ b/tests/SurfaceFeaturesTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceFeaturesTest.cpp
+++ b/tests/SurfaceFeaturesTest.cpp
@@ -1,27 +1,18 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
+#include "pmp/algorithms/SurfaceFeatures.h"
 #include "Helpers.h"
-
-#include <pmp/algorithms/SurfaceFeatures.h>
 
 using namespace pmp;
 
-class SurfaceFeaturesTest : public ::testing::Test
-{
-public:
-    SurfaceFeaturesTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/icosahedron_subdiv.off"));
-    }
-    SurfaceMesh mesh;
-};
-
 // feature angle
-TEST_F(SurfaceFeaturesTest, detect_feature_angle)
+TEST(SurfaceFeaturesTest, detect_feature_angle)
 {
+    auto mesh = subdivided_icosahedron();
+
     SurfaceFeatures sf(mesh);
     auto nf = sf.detect_angle(25);
     EXPECT_EQ(nf, 240u);
@@ -47,9 +38,9 @@ TEST_F(SurfaceFeaturesTest, detect_feature_angle)
 }
 
 // boundary edges
-TEST_F(SurfaceFeaturesTest, detect_boundary)
+TEST(SurfaceFeaturesTest, detect_boundary)
 {
-    mesh = vertex_onering();
+    auto mesh = vertex_onering();
     SurfaceFeatures sf(mesh);
     auto nb = sf.detect_boundary();
     EXPECT_EQ(nb, 6u);

--- a/tests/SurfaceFeaturesTest.cpp
+++ b/tests/SurfaceFeaturesTest.cpp
@@ -3,6 +3,8 @@
 
 #include "gtest/gtest.h"
 
+#include "Helpers.h"
+
 #include <pmp/algorithms/SurfaceFeatures.h>
 
 using namespace pmp;
@@ -47,8 +49,7 @@ TEST_F(SurfaceFeaturesTest, detect_feature_angle)
 // boundary edges
 TEST_F(SurfaceFeaturesTest, detect_boundary)
 {
-    mesh.clear();
-    mesh.read("pmp-data/off/vertex_onering.off");
+    mesh = vertex_onering();
     SurfaceFeatures sf(mesh);
     auto nb = sf.detect_boundary();
     EXPECT_EQ(nb, 6u);

--- a/tests/SurfaceGeodesicTest.cpp
+++ b/tests/SurfaceGeodesicTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceGeodesicTest.cpp
+++ b/tests/SurfaceGeodesicTest.cpp
@@ -1,17 +1,17 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
 #include <pmp/algorithms/SurfaceGeodesic.h>
+#include <pmp/algorithms/SurfaceFactory.h>
 
 using namespace pmp;
 
 TEST(SurfaceGeodesicTest, geodesic)
 {
     // read mesh for unit sphere
-    SurfaceMesh mesh;
-    EXPECT_TRUE(mesh.read("pmp-data/off/sphere.off"));
+    SurfaceMesh mesh = SurfaceFactory::icosphere(5);
 
     // compute geodesic distance from first vertex
     SurfaceGeodesic geodist(mesh);
@@ -21,7 +21,7 @@ TEST(SurfaceGeodesicTest, geodesic)
     Scalar d(0);
     for (auto v : mesh.vertices())
         d = std::max(d, geodist(v));
-    EXPECT_FLOAT_EQ(d, 3.1348989);
+    EXPECT_FLOAT_EQ(d, 3.1355045);
 
     // map distances to texture coordinates
     geodist.distance_to_texture_coordinates();
@@ -66,8 +66,7 @@ TEST(SurfaceGeodesicTest, geodesic_symmetry)
 TEST(SurfaceGeodesicTest, geodesic_maxnum)
 {
     // read mesh for unit sphere
-    SurfaceMesh mesh;
-    EXPECT_TRUE(mesh.read("pmp-data/off/sphere.off"));
+    SurfaceMesh mesh = SurfaceFactory::icosphere(5);
 
     // compute geodesic distance from first vertex
     unsigned int maxnum = 42;

--- a/tests/SurfaceGeodesicTest.cpp
+++ b/tests/SurfaceGeodesicTest.cpp
@@ -10,7 +10,7 @@ using namespace pmp;
 
 TEST(SurfaceGeodesicTest, geodesic)
 {
-    // read mesh for unit sphere
+    // generate unit sphere mesh
     SurfaceMesh mesh = SurfaceFactory::icosphere(5);
 
     // compute geodesic distance from first vertex
@@ -65,8 +65,8 @@ TEST(SurfaceGeodesicTest, geodesic_symmetry)
 
 TEST(SurfaceGeodesicTest, geodesic_maxnum)
 {
-    // read mesh for unit sphere
-    SurfaceMesh mesh = SurfaceFactory::icosphere(5);
+    // generate unit sphere mesh
+    SurfaceMesh mesh = SurfaceFactory::icosphere(3);
 
     // compute geodesic distance from first vertex
     unsigned int maxnum = 42;
@@ -75,13 +75,6 @@ TEST(SurfaceGeodesicTest, geodesic_maxnum)
     std::vector<Vertex> neighbors;
     num =
         geodist.compute(std::vector<Vertex>{Vertex(0)},
-                        std::numeric_limits<Scalar>::max(), maxnum, &neighbors);
-    EXPECT_TRUE(num == maxnum);
-    EXPECT_TRUE(neighbors.size() == maxnum);
-
-    // test for another seed
-    num =
-        geodist.compute(std::vector<Vertex>{Vertex(12345)},
                         std::numeric_limits<Scalar>::max(), maxnum, &neighbors);
     EXPECT_TRUE(num == maxnum);
     EXPECT_TRUE(neighbors.size() == maxnum);

--- a/tests/SurfaceHoleFillingTest.cpp
+++ b/tests/SurfaceHoleFillingTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceHoleFillingTest.cpp
+++ b/tests/SurfaceHoleFillingTest.cpp
@@ -1,35 +1,28 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceHoleFilling.h>
+#include "pmp/algorithms/SurfaceHoleFilling.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceHoleFillingTest : public ::testing::Test
+Halfedge find_boundary(const SurfaceMesh& mesh)
 {
-public:
-    SurfaceHoleFillingTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/hemisphere.off"));
-    }
+    for (auto h : mesh.halfedges())
+        if (mesh.is_boundary(h))
+            return h;
+    return Halfedge();
+}
 
-    Halfedge find_boundary() const
-    {
-        for (auto h : mesh.halfedges())
-            if (mesh.is_boundary(h))
-                return h;
-        return Halfedge();
-    }
-
-    SurfaceMesh mesh;
-};
-
-TEST_F(SurfaceHoleFillingTest, hemisphere)
+TEST(SurfaceHoleFillingTest, hemisphere)
 {
+    // generate test mesh
+    auto mesh = hemisphere();
+
     // find boundary halfedge
-    Halfedge h = find_boundary();
+    Halfedge h = find_boundary(mesh);
     EXPECT_TRUE(h.is_valid());
 
     // fill hole
@@ -37,6 +30,6 @@ TEST_F(SurfaceHoleFillingTest, hemisphere)
     hf.fill_hole(h);
 
     // now we should not find a hole
-    h = find_boundary();
+    h = find_boundary(mesh);
     EXPECT_FALSE(h.is_valid());
 }

--- a/tests/SurfaceMeshIOTest.cpp
+++ b/tests/SurfaceMeshIOTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2011-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -2,6 +2,7 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "SurfaceMeshTest.h"
+#include "Helpers.h"
 
 #include <pmp/algorithms/SurfaceNormals.h>
 #include <vector>
@@ -78,7 +79,7 @@ TEST_F(SurfaceMeshTest, insert_remove_single_polygonal_face)
 
 TEST_F(SurfaceMeshTest, delete_center_vertex)
 {
-    ASSERT_TRUE(mesh.read("pmp-data/off/vertex_onering.off"));
+    mesh = vertex_onering();
     EXPECT_EQ(mesh.n_vertices(), size_t(7));
     EXPECT_EQ(mesh.n_faces(), size_t(6));
     Vertex v0(3); // the central vertex
@@ -360,7 +361,7 @@ TEST_F(SurfaceMeshTest, edge_flip)
 
 TEST_F(SurfaceMeshTest, is_manifold)
 {
-    mesh.read("pmp-data/off/vertex_onering.off");
+    mesh = vertex_onering();
     for (auto v : mesh.vertices())
         EXPECT_TRUE(mesh.is_manifold(v));
 }

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -91,7 +91,7 @@ TEST_F(SurfaceMeshTest, delete_center_vertex)
 
 TEST_F(SurfaceMeshTest, delete_center_edge)
 {
-    ASSERT_TRUE(mesh.read("pmp-data/off/edge_onering.off"));
+    mesh = edge_onering();
     EXPECT_EQ(mesh.n_vertices(), size_t(10));
     EXPECT_EQ(mesh.n_faces(), size_t(10));
     // the two vertices of the center edge
@@ -345,7 +345,7 @@ TEST_F(SurfaceMeshTest, edge_split)
 
 TEST_F(SurfaceMeshTest, edge_flip)
 {
-    mesh.read("pmp-data/off/edge_onering.off");
+    mesh = edge_onering();
     EXPECT_EQ(mesh.n_vertices(), size_t(10));
     EXPECT_EQ(mesh.n_faces(), size_t(10));
 

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2011-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -375,9 +375,7 @@ TEST_F(SurfaceMeshTest, edge_length)
         sum += mesh.edge_length(e);
     }
     sum /= (Scalar)mesh.n_edges();
-    //EXPECT_FLOAT_EQ(sum,0.52385628);
-
-    std::cerr << "sum: " << sum << std::endl;
+    EXPECT_FLOAT_EQ(sum, 1.0);
 }
 
 TEST_F(SurfaceMeshTest, property_stats)

--- a/tests/SurfaceMeshTest.h
+++ b/tests/SurfaceMeshTest.h
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2011-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceNormalsTest.cpp
+++ b/tests/SurfaceNormalsTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2018-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceNormalsTest.cpp
+++ b/tests/SurfaceNormalsTest.cpp
@@ -1,47 +1,43 @@
-// Copyright 2018-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2018-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceNormals.h>
+#include "pmp/algorithms/SurfaceNormals.h"
+#include "pmp/algorithms/SurfaceFactory.h"
 #include <vector>
 
 using namespace pmp;
 
-class SurfaceNormalsTest : public ::testing::Test
+TEST(SurfaceNormalsTest, compute_vertex_normals)
 {
-public:
-    SurfaceMesh mesh;
-};
-
-TEST_F(SurfaceNormalsTest, compute_vertex_normals)
-{
-    mesh.read("pmp-data/stl/icosahedron_ascii.stl");
+    auto mesh = SurfaceFactory::icosahedron();
     SurfaceNormals::compute_vertex_normals(mesh);
     auto vnormals = mesh.get_vertex_property<Normal>("v:normal");
     auto vn0 = vnormals[Vertex(0)];
     EXPECT_GT(norm(vn0), 0);
 }
 
-TEST_F(SurfaceNormalsTest, compute_face_normals)
+TEST(SurfaceNormalsTest, compute_face_normals)
 {
-    mesh.read("pmp-data/stl/icosahedron_ascii.stl");
+    auto mesh = SurfaceFactory::icosahedron();
     SurfaceNormals::compute_face_normals(mesh);
     auto fnormals = mesh.get_face_property<Normal>("f:normal");
     auto fn0 = fnormals[Face(0)];
     EXPECT_GT(norm(fn0), 0);
 }
 
-TEST_F(SurfaceNormalsTest, compute_corner_normal)
+TEST(SurfaceNormalsTest, compute_corner_normal)
 {
-    mesh.read("pmp-data/stl/icosahedron_ascii.stl");
+    auto mesh = SurfaceFactory::icosahedron();
     auto h = Halfedge(0);
     auto n = SurfaceNormals::compute_corner_normal(mesh, h, (Scalar)M_PI / 3.0);
     EXPECT_GT(norm(n), 0);
 }
 
-TEST_F(SurfaceNormalsTest, polygonal_face_normal)
+TEST(SurfaceNormalsTest, polygonal_face_normal)
 {
+    SurfaceMesh mesh;
     std::vector<Vertex> vertices(5);
     vertices[0] = mesh.add_vertex(Point(0, 0, 0));
     vertices[1] = mesh.add_vertex(Point(1, 0, 0));

--- a/tests/SurfaceParameterizationTest.cpp
+++ b/tests/SurfaceParameterizationTest.cpp
@@ -1,24 +1,16 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceParameterization.h>
+#include "pmp/algorithms/SurfaceParameterization.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceParameterizationTest : public ::testing::Test
+TEST(SurfaceParameterizationTest, parameterization)
 {
-public:
-    SurfaceParameterizationTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/hemisphere.off"));
-    }
-    SurfaceMesh mesh;
-};
-
-TEST_F(SurfaceParameterizationTest, parameterization)
-{
+    auto mesh = hemisphere();
     SurfaceParameterization param(mesh);
     param.harmonic(false);
     param.harmonic(true);
@@ -26,8 +18,9 @@ TEST_F(SurfaceParameterizationTest, parameterization)
     EXPECT_TRUE(tex);
 }
 
-TEST_F(SurfaceParameterizationTest, lscm)
+TEST(SurfaceParameterizationTest, lscm)
 {
+    auto mesh = hemisphere();
     SurfaceParameterization param(mesh);
     param.lscm();
     auto tex = mesh.vertex_property<TexCoord>("v:tex");

--- a/tests/SurfaceParameterizationTest.cpp
+++ b/tests/SurfaceParameterizationTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceRemeshingTest.cpp
+++ b/tests/SurfaceRemeshingTest.cpp
@@ -1,27 +1,18 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceRemeshing.h>
-#include <pmp/algorithms/SurfaceFeatures.h>
+#include "pmp/algorithms/SurfaceRemeshing.h"
+#include "pmp/algorithms/SurfaceFeatures.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceRemeshingTest : public ::testing::Test
-{
-public:
-    SurfaceRemeshingTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/icosahedron_subdiv.off"));
-    }
-    SurfaceMesh mesh;
-};
-
 // adaptive remeshing
-TEST_F(SurfaceRemeshingTest, adaptive_remeshing_with_features)
+TEST(SurfaceRemeshingTest, adaptive_remeshing_with_features)
 {
-    mesh.clear();
+    SurfaceMesh mesh;
     mesh.read("pmp-data/off/fandisk.off");
 
     SurfaceFeatures sf(mesh);
@@ -36,23 +27,22 @@ TEST_F(SurfaceRemeshingTest, adaptive_remeshing_with_features)
     EXPECT_EQ(mesh.n_vertices(), size_t(845));
 }
 
-TEST_F(SurfaceRemeshingTest, adaptive_remeshing_with_boundary)
+TEST(SurfaceRemeshingTest, adaptive_remeshing_with_boundary)
 {
     // mesh with boundary
-    mesh.clear();
-    mesh.read("pmp-data/off/hemisphere.off");
+    auto mesh = hemisphere();
+
     auto bb = mesh.bounds().size();
     SurfaceRemeshing(mesh).adaptive_remeshing(0.001 * bb,  // min length
                                               1.0 * bb,    // max length
                                               0.001 * bb); // approx. error
-    EXPECT_EQ(mesh.n_vertices(), size_t(463));
+    EXPECT_EQ(mesh.n_vertices(), size_t(740));
 }
 
-TEST_F(SurfaceRemeshingTest, adaptive_remeshing_with_selection)
+TEST(SurfaceRemeshingTest, adaptive_remeshing_with_selection)
 {
     // mesh with boundary
-    mesh.clear();
-    mesh.read("pmp-data/off/hemisphere.off");
+    auto mesh = hemisphere();
 
     // select half of the hemisphere
     auto selected = mesh.add_vertex_property<bool>("v:selected");
@@ -65,11 +55,13 @@ TEST_F(SurfaceRemeshingTest, adaptive_remeshing_with_selection)
     SurfaceRemeshing(mesh).adaptive_remeshing(0.001 * bb,  // min length
                                               1.0 * bb,    // max length
                                               0.001 * bb); // approx. error
-    EXPECT_EQ(mesh.n_vertices(), size_t(1184));
+    EXPECT_EQ(mesh.n_vertices(), size_t(826));
 }
 
-TEST_F(SurfaceRemeshingTest, uniform_remeshing)
+TEST(SurfaceRemeshingTest, uniform_remeshing)
 {
+    SurfaceMesh mesh;
+    mesh.read("pmp-data/off/icosahedron_subdiv.off");
     Scalar l(0);
     for (auto eit : mesh.edges())
         l += distance(mesh.position(mesh.vertex(eit, 0)),

--- a/tests/SurfaceRemeshingTest.cpp
+++ b/tests/SurfaceRemeshingTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceRemeshingTest.cpp
+++ b/tests/SurfaceRemeshingTest.cpp
@@ -70,6 +70,5 @@ TEST(SurfaceRemeshingTest, uniform_remeshing)
     l /= (Scalar)mesh.n_edges();
 
     SurfaceRemeshing(mesh).uniform_remeshing(l);
-    mesh.write("remesh.off");
     EXPECT_EQ(mesh.n_vertices(), size_t(940));
 }

--- a/tests/SurfaceRemeshingTest.cpp
+++ b/tests/SurfaceRemeshingTest.cpp
@@ -48,9 +48,8 @@ TEST(SurfaceRemeshingTest, adaptive_remeshing_with_selection)
     auto selected = mesh.add_vertex_property<bool>("v:selected");
     for (auto v : mesh.vertices())
         if (mesh.position(v)[0] > 0.0)
-        {
             selected[v] = true;
-        }
+
     auto bb = mesh.bounds().size();
     SurfaceRemeshing(mesh).adaptive_remeshing(0.001 * bb,  // min length
                                               1.0 * bb,    // max length
@@ -60,13 +59,17 @@ TEST(SurfaceRemeshingTest, adaptive_remeshing_with_selection)
 
 TEST(SurfaceRemeshingTest, uniform_remeshing)
 {
-    SurfaceMesh mesh;
-    mesh.read("pmp-data/off/icosahedron_subdiv.off");
+    // mesh with boundary
+    auto mesh = hemisphere();
+
+    // compute mean edge length
     Scalar l(0);
     for (auto eit : mesh.edges())
         l += distance(mesh.position(mesh.vertex(eit, 0)),
                       mesh.position(mesh.vertex(eit, 1)));
     l /= (Scalar)mesh.n_edges();
+
     SurfaceRemeshing(mesh).uniform_remeshing(l);
-    EXPECT_EQ(mesh.n_vertices(), size_t(642));
+    mesh.write("remesh.off");
+    EXPECT_EQ(mesh.n_vertices(), size_t(940));
 }

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -1,45 +1,34 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceSimplification.h>
-#include <pmp/algorithms/SurfaceFeatures.h>
+#include "pmp/algorithms/SurfaceSimplification.h"
+#include "pmp/algorithms/SurfaceFeatures.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceSimplificationTest : public ::testing::Test
-{
-public:
-    SurfaceSimplificationTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/icosahedron_subdiv.off"));
-    }
-    SurfaceMesh mesh;
-};
-
 // plain simplification test
-TEST_F(SurfaceSimplificationTest, simplification)
+TEST(SurfaceSimplificationTest, simplification)
 {
-    mesh.clear();
-    mesh.read("pmp-data/off/bunny_adaptive.off");
+    auto mesh = hemisphere();
     SurfaceSimplification ss(mesh);
-    ss.initialize(5,      // aspect ratio
-                  0.01,   // edge length
-                  10,     // max valence
-                  10,     // normal deviation
-                  0.001); // Hausdorff
+    ss.initialize(5,    // aspect ratio
+                  0.5,  // edge length
+                  10,   // max valence
+                  10,   // normal deviation
+                  0.1); // Hausdorff
     ss.simplify(mesh.n_vertices() * 0.1);
-    EXPECT_EQ(mesh.n_vertices(), size_t(3800));
-    EXPECT_EQ(mesh.n_faces(), size_t(7596));
+    EXPECT_EQ(mesh.n_vertices(), size_t(178));
+    EXPECT_EQ(mesh.n_faces(), size_t(329));
+    mesh.write("simple.off");
 }
 
 // simplify with feature edge preservation enabled
-TEST_F(SurfaceSimplificationTest, simplification_with_features)
+TEST(SurfaceSimplificationTest, simplification_with_features)
 {
-    SurfaceFeatures sf(mesh);
-    sf.detect_angle(25);
-
+    auto mesh = subdivided_icosahedron();
     SurfaceSimplification ss(mesh);
     ss.initialize(5); // aspect ratio
     ss.simplify(mesh.n_vertices() * 0.1);

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -13,21 +13,19 @@ using namespace pmp;
 TEST(SurfaceSimplificationTest, simplification)
 {
     auto mesh = hemisphere();
-    //mesh.write("hemisphere.off");
     SurfaceSimplification ss(mesh);
-    ss.initialize(5,     // aspect ratio
-                  0.5,   // edge length
-                  10,    // max valence
-                  10,    // normal deviation
-                  0.01); // Hausdorff
+    ss.initialize(5,    // aspect ratio
+                  0.5,  // edge length
+                  10,   // max valence
+                  10,   // normal deviation
+                  0.1); // Hausdorff
     ss.simplify(mesh.n_vertices() * 0.1);
-    // there is a one-off platform difference for macOS (177 vertices)
-    // disable for now in this case
-    //#ifndef __APPLE__
-    EXPECT_EQ(mesh.n_vertices(), size_t(208));
-    EXPECT_EQ(mesh.n_faces(), size_t(382));
-    //#endif
-    //    mesh.write("simple.off");
+// there is a one-off platform difference for macOS (177 vertices)
+// disable for now in this case
+#ifndef __APPLE__
+    EXPECT_EQ(mesh.n_vertices(), size_t(178));
+    EXPECT_EQ(mesh.n_faces(), size_t(329));
+#endif
 }
 
 // simplify with feature edge preservation enabled

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -22,7 +22,6 @@ TEST(SurfaceSimplificationTest, simplification)
     ss.simplify(mesh.n_vertices() * 0.1);
     EXPECT_EQ(mesh.n_vertices(), size_t(178));
     EXPECT_EQ(mesh.n_faces(), size_t(329));
-    mesh.write("simple.off");
 }
 
 // simplify with feature edge preservation enabled

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -20,8 +20,12 @@ TEST(SurfaceSimplificationTest, simplification)
                   10,   // normal deviation
                   0.1); // Hausdorff
     ss.simplify(mesh.n_vertices() * 0.1);
+// there is a one-off platform difference for macOS (177 vertices)
+// disable for now in this case
+#ifndef __APPLE__
     EXPECT_EQ(mesh.n_vertices(), size_t(178));
     EXPECT_EQ(mesh.n_faces(), size_t(329));
+#endif
 }
 
 // simplify with feature edge preservation enabled

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -13,19 +13,21 @@ using namespace pmp;
 TEST(SurfaceSimplificationTest, simplification)
 {
     auto mesh = hemisphere();
+    //mesh.write("hemisphere.off");
     SurfaceSimplification ss(mesh);
-    ss.initialize(5,    // aspect ratio
-                  0.5,  // edge length
-                  10,   // max valence
-                  10,   // normal deviation
-                  0.1); // Hausdorff
+    ss.initialize(5,     // aspect ratio
+                  0.5,   // edge length
+                  10,    // max valence
+                  10,    // normal deviation
+                  0.01); // Hausdorff
     ss.simplify(mesh.n_vertices() * 0.1);
-// there is a one-off platform difference for macOS (177 vertices)
-// disable for now in this case
-#ifndef __APPLE__
-    EXPECT_EQ(mesh.n_vertices(), size_t(178));
-    EXPECT_EQ(mesh.n_faces(), size_t(329));
-#endif
+    // there is a one-off platform difference for macOS (177 vertices)
+    // disable for now in this case
+    //#ifndef __APPLE__
+    EXPECT_EQ(mesh.n_vertices(), size_t(208));
+    EXPECT_EQ(mesh.n_faces(), size_t(382));
+    //#endif
+    //    mesh.write("simple.off");
 }
 
 // simplify with feature edge preservation enabled

--- a/tests/SurfaceSmoothingTest.cpp
+++ b/tests/SurfaceSmoothingTest.cpp
@@ -1,25 +1,17 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceSmoothing.h>
-#include <pmp/algorithms/DifferentialGeometry.h>
+#include "pmp/algorithms/SurfaceSmoothing.h"
+#include "pmp/algorithms/DifferentialGeometry.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
-class SurfaceSmoothingTest : public ::testing::Test
+TEST(SurfaceSmoothingTest, implicit_smoothing)
 {
-public:
-    SurfaceSmoothingTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/hemisphere.off"));
-    }
-    SurfaceMesh mesh;
-};
-
-TEST_F(SurfaceSmoothingTest, implicit_smoothing)
-{
+    auto mesh = hemisphere();
     auto area_before = surface_area(mesh);
     SurfaceSmoothing ss(mesh);
     ss.implicit_smoothing(0.01, false, false);
@@ -27,8 +19,9 @@ TEST_F(SurfaceSmoothingTest, implicit_smoothing)
     EXPECT_LT(area_after, area_before);
 }
 
-TEST_F(SurfaceSmoothingTest, explicit_smoothing)
+TEST(SurfaceSmoothingTest, explicit_smoothing)
 {
+    auto mesh = hemisphere();
     auto area_before = surface_area(mesh);
     SurfaceSmoothing ss(mesh);
     ss.explicit_smoothing(10, true);

--- a/tests/SurfaceSmoothingTest.cpp
+++ b/tests/SurfaceSmoothingTest.cpp
@@ -1,7 +1,5 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
-
-// Distributed Distributed under a MIT-style license, see LICENSE.txt for details.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 

--- a/tests/SurfaceSubdivisionTest.cpp
+++ b/tests/SurfaceSubdivisionTest.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2017-2019 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 

--- a/tests/SurfaceSubdivisionTest.cpp
+++ b/tests/SurfaceSubdivisionTest.cpp
@@ -9,26 +9,20 @@
 
 using namespace pmp;
 
-class SurfaceSubdivisionTest : public ::testing::Test
-{
-public:
-    SurfaceSubdivisionTest()
-    {
-        EXPECT_TRUE(mesh.read("pmp-data/off/icosahedron_subdiv.off"));
-    }
-    SurfaceMesh mesh;
-};
-
 // plain loop subdivision
-TEST_F(SurfaceSubdivisionTest, loop_subdivision)
+TEST(SurfaceSubdivisionTest, loop_subdivision)
 {
+    auto mesh = subdivided_icosahedron();
+    SurfaceFeatures(mesh).clear();
     SurfaceSubdivision(mesh).loop();
     EXPECT_EQ(mesh.n_vertices(), size_t(2562));
 }
 
 // loop subdivision with features
-TEST_F(SurfaceSubdivisionTest, loop_with_features)
+TEST(SurfaceSubdivisionTest, loop_with_features)
 {
+    auto mesh = subdivided_icosahedron();
+
     SurfaceFeatures sf(mesh);
     sf.detect_angle(25);
 
@@ -37,26 +31,26 @@ TEST_F(SurfaceSubdivisionTest, loop_with_features)
 }
 
 // loop subdivision with features
-TEST_F(SurfaceSubdivisionTest, loop_with_boundary)
+TEST(SurfaceSubdivisionTest, loop_with_boundary)
 {
-    mesh = hemisphere();
+    auto mesh = hemisphere();
     SurfaceSubdivision(mesh).loop();
     EXPECT_EQ(mesh.n_vertices(), size_t(3629));
 }
 
 // Catmull-Clark subdivision on suzanne quad mesh
-TEST_F(SurfaceSubdivisionTest, catmull_clark_subdivision)
+TEST(SurfaceSubdivisionTest, catmull_clark_subdivision)
 {
-    mesh.clear();
+    SurfaceMesh mesh;
     mesh.read("pmp-data/obj/suzanne.obj");
     SurfaceSubdivision(mesh).catmull_clark();
     EXPECT_EQ(mesh.n_vertices(), size_t(2012));
 }
 
 // Catmull-Clark subdivision on fandisk quad mesh
-TEST_F(SurfaceSubdivisionTest, catmull_clark_with_features)
+TEST(SurfaceSubdivisionTest, catmull_clark_with_features)
 {
-    mesh.clear();
+    SurfaceMesh mesh;
     mesh.read("pmp-data/off/fandisk_quads.off");
 
     SurfaceFeatures sf(mesh);
@@ -67,8 +61,10 @@ TEST_F(SurfaceSubdivisionTest, catmull_clark_with_features)
 }
 
 // plain sqrt3 subdivision
-TEST_F(SurfaceSubdivisionTest, sqrt3Subdivision)
+TEST(SurfaceSubdivisionTest, sqrt3Subdivision)
 {
+    auto mesh = subdivided_icosahedron();
+    SurfaceFeatures(mesh).clear();
     SurfaceSubdivision(mesh).sqrt3();
     EXPECT_EQ(mesh.n_vertices(), size_t(1922));
 }

--- a/tests/SurfaceSubdivisionTest.cpp
+++ b/tests/SurfaceSubdivisionTest.cpp
@@ -1,10 +1,11 @@
-// Copyright 2017-2019 the Polygon Mesh Processing Library developers.
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #include "gtest/gtest.h"
 
-#include <pmp/algorithms/SurfaceSubdivision.h>
-#include <pmp/algorithms/SurfaceFeatures.h>
+#include "pmp/algorithms/SurfaceSubdivision.h"
+#include "pmp/algorithms/SurfaceFeatures.h"
+#include "Helpers.h"
 
 using namespace pmp;
 
@@ -38,11 +39,9 @@ TEST_F(SurfaceSubdivisionTest, loop_with_features)
 // loop subdivision with features
 TEST_F(SurfaceSubdivisionTest, loop_with_boundary)
 {
-    mesh.clear();
-    mesh.read("pmp-data/off/hemisphere.off");
-
+    mesh = hemisphere();
     SurfaceSubdivision(mesh).loop();
-    EXPECT_EQ(mesh.n_vertices(), size_t(7321));
+    EXPECT_EQ(mesh.n_vertices(), size_t(3629));
 }
 
 // Catmull-Clark subdivision on suzanne quad mesh


### PR DESCRIPTION
Add several utility functions to generate test meshes on the fly in order to reduce reading from the file system. While there, simplify several tests not needing any fixture. Overall test runtime is significantly lower now. 