### PR TITLE
Improve documentation

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1638,11 +1638,12 @@ public:
         return insert_vertex(halfedge(e, 0), v);
     }
 
-    //! Subdivide the edge \p e = (v0,v1) by splitting it into the two edge
-    //! (v0,v) and (v,v1). Note that this function does not introduce any
-    //! other edge or faces. It simply splits the edge. Returns halfedge
-    //! that points to \p p.  \sa insert_vertex(Edge, Point) \sa
-    //! insert_vertex(Edge, Vertex)
+    //! Subdivide the halfedge \p h = (v0,v1) by splitting it into the two halfedges 
+    //! (v0,v) and (v,v1). Note that this function does not introduce any 
+    //! other edge or faces. It simply splits the edge. Returns the halfedge 
+    //! that points from v1 to \p v.
+    //! \sa insert_vertex(Edge, Point)
+    //! \sa insert_vertex(Edge, Vertex)
     Halfedge insert_vertex(Halfedge h0, Vertex v);
 
     //! find the halfedge from start to end
@@ -1717,9 +1718,9 @@ public:
     //! \sa split(Edge, Point)
     Halfedge split(Edge e, Vertex v);
 
-    //! insert edge between the to-vertices v0 of h0 and v1 of h1.
+    //! insert edge between the to-vertices v0 of \p h0 and v1 of \p h1.
     //! returns the new halfedge from v0 to v1.
-    //! \attention h0 and h1 have to belong to the same face
+    //! \attention \p h0 and \p h1 have to belong to the same face
     Halfedge insert_edge(Halfedge h0, Halfedge h1);
 
     //! Check whether flipping edge \p e is topologically


### PR DESCRIPTION
Changes the documentation in some methods.

Signed-off-by: João Baptista de Paula e Silva <jbaptistapsilva@yahoo.com.br>

# Description

This pull request is a small change to the documentation of `insert_vertex` to remove the ambiguity between edges and halfedges, also making explicit the return value of the method.

# Motivation

Since pmp-library treats edges and halfedges differently than edges, this can cause confusion as to which method to use.

# Benefits

Improved documentation

# Drawbacks

None

# Applicable Issues

None
