### PR TITLE
Fix const-correctness on `bounds()` & skip deleted vertices

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1766,11 +1766,11 @@ public:
     std::vector<Point>& positions() { return vpoint_.vector(); }
 
     //! compute the bounding box of the object
-    BoundingBox bounds()
+    BoundingBox bounds() const
     {
         BoundingBox bb;
-        for (auto p : positions())
-            bb += p;
+        for (auto v : vertices())
+            bb += position(v);
         return bb;
     }
 


### PR DESCRIPTION
# Description

Adds a `const` qualifier to the method `bounds()` of the class `SurfaceMesh` and use `vertices()` to iterate only over existing vertices instead of `positions()`.
    
Signed-off-by: Paul Du <du.paul136@gmail.com>

# Motivation

Share the bugfix with upstream.

# Benefits

- Be able to compute the bounding box of a read-only `const pmp::SurfaceMesh`.
- Avoid deleted vertices in the computation of the bounding box

# Drawbacks

- Can break existing usages that really mean to include deleted vertices (but I don't know why someone would do that)

# Applicable Issues

None.
