### PR TITLE
New feature: remove center vertex

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1684,6 +1684,9 @@ public:
     //! and that these two are not equal.
     bool remove_edge(Edge e);
 
+    //! Remove vertex and its incident halfedges by merging all incident faces.
+    void remove_center_vertex(Vertex v);
+
     //! Split the face \p f by first adding point \p p to the mesh and then
     //! inserting edges between \p p and the vertices of \p f. For a triangle
     //! this is a standard one-to-three split.

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -314,6 +314,26 @@ TEST_F(SurfaceMeshTest, collapse)
     EXPECT_EQ(mesh.n_faces(), size_t(1));
 }
 
+TEST_F(SurfaceMeshTest, remove_center_vertex)
+{
+    Vertex v0 = mesh.add_vertex(Point(0, 0, 0));
+    Vertex v1 = mesh.add_vertex(Point(1, 0, 0));
+    Vertex v2 = mesh.add_vertex(Point(0, 1, 0));
+    Vertex v3 = mesh.add_vertex(Point(-1, 0, 0));
+    Vertex v4 = mesh.add_vertex(Point(0, -1, 0));
+    EXPECT_EQ(mesh.n_vertices(), 5);
+
+    mesh.add_triangle(v0, v1, v2);
+    mesh.add_triangle(v0, v2, v3);
+    mesh.add_triangle(v0, v3, v4);
+    mesh.add_triangle(v0, v4, v1);
+    EXPECT_EQ(mesh.n_faces(), 4);
+
+    mesh.remove_center_vertex(v0);
+    EXPECT_EQ(mesh.n_vertices(), 4);
+    EXPECT_EQ(mesh.n_faces(), 1);
+}
+
 TEST_F(SurfaceMeshTest, face_split)
 {
     add_quad();


### PR DESCRIPTION
# Description

Add a new topological operation to remove a vertex and its incident halfedges by merging all incident faces.

In other words, it's the reverse operation of `void split(Face f, Vertex v);`

# Motivation

Share the implementation with the upstream.

# Benefits

To have `void split(Face f, Vertex v);` and its reverse operation.

# Drawbacks

None.

# Applicable Issues

None.
