### PR TITLE
Reimplement free_memory according to C++11

### DIFF
--- a/src/pmp/Properties.h
+++ b/src/pmp/Properties.h
@@ -72,7 +72,7 @@ public: // virtual interface of BasePropertyArray
 
     virtual void push_back() { data_.push_back(value_); }
 
-    virtual void free_memory() { VectorType(data_).swap(data_); }
+    virtual void free_memory() { data_.shrink_to_fit(); }
 
     virtual void swap(size_t i0, size_t i1)
     {


### PR DESCRIPTION
# Description

Use `shrink_to_fit()` instead of the idiom copy-and-swap.

# Motivation

Share the change with upstream.

# Benefits

- Can be a no-op if there is nothing to shrink or if the C++ implementation determines that it's not worth do it.
- Someday, maybe, we could have an implementation that `realloc`s the vector instead of copying it.

# Drawbacks

- The request to `free_memory` is not binding anymore.

# Applicable Issues

None.
