### PR TITLE
New feature: split vertex

### DIFF
--- a/src/pmp/SurfaceMesh.cpp
+++ b/src/pmp/SurfaceMesh.cpp
@@ -637,6 +637,39 @@ Halfedge SurfaceMesh::split(Edge e, Vertex v)
     return t1;
 }
 
+Halfedge SurfaceMesh::split_vertex(Halfedge h0, Halfedge h1, Vertex v)
+{
+    PMP_ASSERT(h0 != h1);
+    PMP_ASSERT(to_vertex(h0) == to_vertex(h1));
+
+    Vertex v2 = to_vertex(h0);
+    Halfedge h_new = new_edge(v, v2);
+    Halfedge h_new_opp = opposite_halfedge(h_new);
+
+    set_next_halfedge(h_new, next_halfedge(h1));
+    set_next_halfedge(h1, h_new);
+    set_face(h_new, face(h1));
+
+    set_next_halfedge(h_new_opp, next_halfedge(h0));
+    set_next_halfedge(h0, h_new_opp);
+    set_face(h_new_opp, face(h0));
+
+    Halfedge end = h_new_opp;
+    do
+    {
+        set_vertex(h_new_opp, v);
+        h_new_opp = opposite_halfedge(next_halfedge(h_new_opp));
+    } while (h_new_opp != end);
+
+    set_halfedge(v, h_new);
+    set_halfedge(v2, h_new_opp);
+
+    adjust_outgoing_halfedge(v);
+    adjust_outgoing_halfedge(v2);
+
+    return h_new;
+}
+
 Halfedge SurfaceMesh::insert_vertex(Halfedge h0, Vertex v)
 {
     // before:

--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1718,6 +1718,17 @@ public:
     //! \sa split(Edge, Point)
     Halfedge split(Edge e, Vertex v);
 
+    //! Split the vertex that is the target of both halfedges \p h0 and \p h1 
+    //! by creating a halfedge pointing to \p v and rearranging the patch around 
+    //! the old vertex so its halfedges point to the correct vertices. Returns the 
+    //! halfedge created from that split that points to the vertex pointed by both 
+    //! \p h0 and \p h1 .
+    //! \pre \p h0 and \p h1 must point to the same vertex
+    //! \pre \p v must be an isolated vertex (e.g. a new vertex)
+    //! \post The returned halfedge points from \p v to the common target of 
+    //! \p h0 and \p h1 . \p h0 now points to \p v .
+    Halfedge split_vertex(Halfedge h0, Halfedge h1, Vertex v);
+
     //! insert edge between the to-vertices v0 of \p h0 and v1 of \p h1.
     //! returns the new halfedge from v0 to v1.
     //! \attention \p h0 and \p h1 have to belong to the same face

--- a/tests/SurfaceMeshTest.cpp
+++ b/tests/SurfaceMeshTest.cpp
@@ -335,6 +335,40 @@ TEST_F(SurfaceMeshTest, edge_split)
     EXPECT_EQ(mesh.n_faces(), size_t(2));
 }
 
+TEST_F(SurfaceMeshTest, vertex_split)
+{
+    Vertex v0 = mesh.add_vertex(Point(0, 0, 0));
+    Vertex v1 = mesh.add_vertex(Point(1, 0, 0));
+    Vertex v2 = mesh.add_vertex(Point(0, 1, 0));
+    Vertex v3 = mesh.add_vertex(Point(-1, 0, 0));
+    Vertex v4 = mesh.add_vertex(Point(0, -1, 0));
+
+    Face f1 = mesh.add_triangle(v0, v1, v2);
+    Face f2 = mesh.add_triangle(v0, v2, v3);
+    Face f3 = mesh.add_triangle(v0, v3, v4);
+    Face f4 = mesh.add_triangle(v0, v4, v1);
+
+    Halfedge h1 = mesh.find_halfedge(v1, v0);
+    Halfedge h2 = mesh.find_halfedge(v2, v0);
+    Halfedge h3 = mesh.find_halfedge(v3, v0);
+    Halfedge h4 = mesh.find_halfedge(v4, v0);
+
+    Vertex v5 = mesh.add_vertex(Point(0, 0, 1));
+    Halfedge h = mesh.split_vertex(h1, h3, v5);
+    EXPECT_EQ(mesh.from_vertex(h), v5);
+    EXPECT_EQ(mesh.to_vertex(h), v0);
+
+    EXPECT_EQ(mesh.valence(f1), 3);
+    EXPECT_EQ(mesh.valence(f2), 4);
+    EXPECT_EQ(mesh.valence(f3), 3);
+    EXPECT_EQ(mesh.valence(f4), 4);
+
+    EXPECT_EQ(mesh.to_vertex(h1), v0);
+    EXPECT_EQ(mesh.to_vertex(h2), v0);
+    EXPECT_EQ(mesh.to_vertex(h3), v5);
+    EXPECT_EQ(mesh.to_vertex(h4), v5);
+}
+
 TEST_F(SurfaceMeshTest, edge_flip)
 {
     mesh = edge_onering();


### PR DESCRIPTION
# Description

Add a new topological operation to split a vertex into two, correctly adjusting the halfedges of the patch around it to point to the new vertex where necessary.

Schema for `Halfedge split_vertex(Halfedge h0, Halfedge h1, Vertex v);` :
![image](https://user-images.githubusercontent.com/1014604/129008515-20c514f3-1dd1-4217-b93b-5e29aebe492a.png)

# Motivation

Share the implementation with upstream.

# Benefits

A new topological operation available.

# Drawbacks

None.

# Applicable Issues

None.
