### PR TITLE
Don't garbage collect when not needed

### DIFF
--- a/src/pmp/SurfaceMesh.cpp
+++ b/src/pmp/SurfaceMesh.cpp
@@ -1182,6 +1182,9 @@ void SurfaceMesh::delete_face(Face f)
 
 void SurfaceMesh::garbage_collection()
 {
+    if (!has_garbage_)
+        return;
+
     int i, i0, i1, nV(vertices_size()), nE(edges_size()), nH(halfedges_size()),
         nF(faces_size());
 


### PR DESCRIPTION
# Description

Add a check to do nothing if the SurfaceMesh has no garbage.

Signed-off-by: Paul Du <du.paul136@gmail.com>

# Motivation

Since `has_garbage_` is `private`, there is no short way to know if there is something to garbage collect or not.

# Benefits

Since `garbage_collection` is an expensive operation, a simple check to avoid it if unnecessary is quite worth it.

# Drawbacks

None.

# Applicable Issues

None.
