### PR TITLE
Surface remeshing crash fix

### DIFF
--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -819,7 +819,10 @@ Point SurfaceRemeshing::minimize_squared_areas(Vertex v)
 
     // compute minimizer
     Eigen::Vector3d x = H.lu().solve(-J);
-
+    if (isnan(x[0]) || isnan(x[1]) || isnan(x[2]))
+    {
+        return mesh_.position(v);
+    }
     return Point(x);
 }
 

--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -819,7 +819,7 @@ Point SurfaceRemeshing::minimize_squared_areas(Vertex v)
 
     // compute minimizer
     Eigen::Vector3d x = H.lu().solve(-J);
-    if (isnan(x[0]) || isnan(x[1]) || isnan(x[2]))
+    if (!x.allFinite())
     {
         return mesh_.position(v);
     }

--- a/src/pmp/algorithms/SurfaceRemeshing.h
+++ b/src/pmp/algorithms/SurfaceRemeshing.h
@@ -59,8 +59,10 @@ private:
 
     bool is_too_long(Vertex v0, Vertex v1) const
     {
-        return distance(points_[v0], points_[v1]) >
-               4.0 / 3.0 * std::min(vsizing_[v0], vsizing_[v1]);
+        auto point_distance = distance(points_[v0], points_[v1]);
+        Scalar min_vsizing = 4.0 / 3.0 * std::min(vsizing_[v0], vsizing_[v1]);
+        auto min_dist = std::max(min_vsizing, min_edge_length_);
+        return point_distance > min_dist;
     }
     bool is_too_short(Vertex v0, Vertex v1) const
     {


### PR DESCRIPTION
# Description

Performing SurfaceRemeshing Adaptive with Features can lead to crashes.

To reproduce the crash do the following

- Start the remeshing project with a mesh file that has degenerated triangles and kinks (if you need a concrete file for reproduction I can provide you one)
  The remeshing project does not work in the latest commit as already reported in Issue
  Inheriting from MeshViewer on Windows crashes due to the imgui context being null #87.
  The latest working commit is as far as I know SHA-1: 3145a49262dcdc0586bb0669b6e85da65f18a4fb
- Click Detect Features with 70
- Execute Adaptive remeshing 
  The program will crash because mesh_->halfedge(f) is called with an invalid Face f


The reason for this crash is, that for some degenerated triangles solving minimize_squared_areas lead to an vector containing nan, so one solution is to check at the end of minimize_squared_areas if the solved vector contains invalid values.
	
By doing so the crash is prevented but it takes a really long time to solve (might be an endless loop).
One solution for this might be to change the function is_too_long, so that an edge is never to long if it is smaller than min_edge_length_.
 

# Motivation

Adaptive surface remeshing with features should not crash

# Benefits

no crash

# Drawbacks

I am not sure if there is a reason that an edge is currently allowed to be smaller than min_edge_length_, but everything seems to work with the change.

Maybe it would be better to abort the calculation if it is not possible to calculate the minimize_squared_areas.

