### PR TITLE
Test for UV-Decimation

### DIFF
--- a/src/pmp/algorithms/SurfaceSimplification.cpp
+++ b/src/pmp/algorithms/SurfaceSimplification.cpp
@@ -606,7 +606,7 @@ void SurfaceSimplification::preprocess_collapse(const CollapseData& cd)
                 }
 
                 // loop case 2
-                if (mesh_.to_vertex(mesh_.prev_halfedge(o)) ==
+                if (mesh_.to_vertex(mesh_.next_halfedge(o)) ==
                     mesh_.from_vertex(hit))
                 {
                     v2v1 = mesh_.prev_halfedge(o);

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -122,4 +122,76 @@ SurfaceMesh open_cone()
     return mesh;
 }
 
+
+SurfaceMesh texture_seams_mesh()
+{
+    SurfaceMesh mesh;
+    auto v0 = mesh.add_vertex(Point(0.5999997854, 0.5196152329, 0.0000000000));
+    auto v1 = mesh.add_vertex(Point(0.4499998093, 0.5196152329, -0.001000000));
+    auto v2 = mesh.add_vertex(Point(0.2999998033, 0.5196152329, 0.0000000000));
+    auto v3 = mesh.add_vertex(Point(0.6749998331, 0.3897114396, -0.001000000));
+    auto v4 = mesh.add_vertex(Point(0.5249998569, 0.3897114396, 0.0000000000));
+    auto v5 = mesh.add_vertex(Point(0.3749998510, 0.3897114396, 0.0000000000));
+    auto v6 = mesh.add_vertex(Point(0.2249998450, 0.3897114396, 0.0000000000));
+    auto v7 = mesh.add_vertex(Point(0.5999999046, 0.2598076165, 0.0000000000));
+    auto v8 = mesh.add_vertex(Point(0.4499999285, 0.2598076165, 0.0000000000));
+    auto v9 = mesh.add_vertex(Point(0.2999999225, 0.2598076165, 0.0000000000));
+    auto v10 = mesh.add_vertex(Point(0.749999285, 0.2598076165, 0.0000000000));
+    auto v11 = mesh.add_vertex(Point(0.8249998331, 0.3897114396, 0.0000000000));
+    auto v12 = mesh.add_vertex(Point(0.749999285, 0.5196152329, 0.0000000000));
+    auto v13 = mesh.add_vertex(Point(0.6749998331, 0.6496152329, 0.0000000000));
+    auto v14 = mesh.add_vertex(Point(0.5249998569, 0.6496152329, 0.0000000000));
+    auto v15 = mesh.add_vertex(Point(0.3749998510, 0.6496152329, 0.0000000000));
+
+    mesh.add_triangle(v4, v0, v1);
+    mesh.add_triangle(v4, v3, v0);
+    mesh.add_triangle(v15, v4, v1);
+    mesh.add_triangle(v2, v5, v4);
+    mesh.add_triangle(v6, v5, v2);
+    mesh.add_triangle(v7, v11, v4);
+    mesh.add_triangle(v8, v7, v4);
+    mesh.add_triangle(v8, v4, v5);
+    mesh.add_triangle(v9, v8, v5);
+    mesh.add_triangle(v9, v5, v6);
+    mesh.add_triangle(v7, v10, v11);
+    mesh.add_triangle(v4, v11, v3);
+    mesh.add_triangle(v3, v11, v12);
+    mesh.add_triangle(v3, v12, v0);
+    mesh.add_triangle(v0, v12, v13);
+    mesh.add_triangle(v0, v13, v14);
+    mesh.add_triangle(v0, v14, v1);
+    mesh.add_triangle(v1, v14, v15);
+    mesh.add_triangle(v2, v4, v15);
+    
+
+     // add test texcoords
+    auto texcoords = mesh.halfedge_property<vec2>("h:tex");
+    
+    for(auto v: mesh.vertices())
+    {
+        Point p = mesh.position(v);
+        for(auto h: mesh.halfedges(v))
+        {
+            if(mesh.is_boundary(mesh.opposite_halfedge(h)))
+            {
+               continue;
+            }
+            texcoords[mesh.opposite_halfedge(h)] = TexCoord(p[0], p[1]);
+        }
+    }
+
+    // change texcoords to create a texture seam
+    std::vector<Face> faces = {Face(0), Face(1), Face(12), Face(13), 
+                               Face(14), Face(15), Face(16), Face(17)};
+    for(auto f : faces)
+    {
+        for(auto h : mesh.halfedges(f))
+        {
+            texcoords[h] += TexCoord(0.1, 0.1);
+        }
+    }
+
+    return mesh;
+}
+
 } // namespace pmp

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -24,4 +24,7 @@ SurfaceMesh l_shape();
 // generate cone with bottom polygon removed
 SurfaceMesh open_cone();
 
+// a mesh with texcoords and texture seams
+SurfaceMesh texture_seams_mesh();
+
 } // namespace pmp

--- a/tests/SurfaceSimplificationTest.cpp
+++ b/tests/SurfaceSimplificationTest.cpp
@@ -34,3 +34,40 @@ TEST(SurfaceSimplificationTest, simplification_with_features)
     ss.simplify(mesh.n_vertices() * 0.01);
     EXPECT_EQ(mesh.n_vertices(), size_t(12));
 }
+
+// simplify with respect to texture coordinates and seams
+TEST(SurfaceSimplificationTest, simplification_texture_mesh)
+{
+    SurfaceMesh mesh = texture_seams_mesh();
+    
+    // if the test mesh does not have texcoords,
+    // this test won't work
+    ASSERT_EQ(mesh.get_halfedge_property<TexCoord>("h:tex"), 1);
+    
+    SurfaceSimplification ss(mesh);
+    ss.initialize(10.0,  // aspect ratio
+                  0.0,   // edge length
+                  0.0,   // max valence
+                  135.0, // normal deviation
+                  0.0,   // Hausdorff
+                  1e-2,  // seam threshold
+                  1);    // seam angle deviation
+
+    ss.simplify(mesh.n_vertices() - 4);
+
+    size_t seam_edges = 0;
+    auto seams = mesh.get_edge_property<bool>("e:seam");
+    for(auto e : mesh.edges())
+        if(seams[e])
+            seam_edges++;
+
+    // test loop case 2
+    auto se = mesh.find_edge(Vertex(4), Vertex(11));
+    // test loop case 1
+    auto se2 = mesh.find_edge(Vertex(4), Vertex(0));
+
+    EXPECT_EQ(mesh.n_vertices(), size_t(12));
+    EXPECT_EQ(seam_edges, size_t(13));
+    EXPECT_EQ(seams[se], 1);
+    EXPECT_EQ(seams[se2], 1);
+}


### PR DESCRIPTION
# Description

This change fixes a bug in the preprocessing of an edge collapse when simplifying a mesh with texture coordinates. Furthermore, a test is added that covers the texture coordinate specific part in the surface simplification.

# Benefits

- The code coverage will be improved. 
- A special loop case will be detected correctly.