### PR TITLE
Fixed implicit numeric conversion warnings in headers.

### DIFF
--- a/src/pmp/BoundingBox.h
+++ b/src/pmp/BoundingBox.h
@@ -64,7 +64,7 @@ public:
     }
 
     //! Get the size of the bounding box.
-    Scalar size() const { return is_empty() ? 0.0 : distance(max_, min_); }
+    Scalar size() const { return is_empty() ? Scalar(0.0) : distance(max_, min_); }
 
 private:
     Point min_, max_;

--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -190,14 +190,14 @@ public:
         {
             assert(m.size() == size());
             for (int i = 0; i < size(); ++i)
-                (*this)[i] = m(i);
+                (*this)[i] = static_cast<Scalar>(m(i));
         }
         else
         {
             assert(m.rows() == rows() && m.cols() == cols());
             for (int i = 0; i < rows(); ++i)
                 for (int j = 0; j < cols(); ++j)
-                    (*this)(i, j) = m(i, j);
+                    (*this)(i, j) = static_cast<Scalar>(m(i, j));
         }
         return *this;
     }
@@ -254,7 +254,7 @@ public:
     void normalize()
     {
         Scalar n = norm(*this);
-        n = (n > std::numeric_limits<Scalar>::min()) ? 1.0 / n : 0.0;
+        n = (n > std::numeric_limits<Scalar>::min()) ? Scalar(1.0) / n : Scalar(0.0);
         *this *= n;
     }
 
@@ -503,7 +503,7 @@ template <typename Scalar, typename Scalar2, int M, int N>
 inline Matrix<Scalar, M, N> operator*(const Scalar2 s,
                                       const Matrix<Scalar, M, N>& m)
 {
-    return Matrix<Scalar, M, N>(m) *= s;
+    return Matrix<Scalar, M, N>(m) *= static_cast<Scalar>(s);
 }
 
 //! scalar multiplication of matrix: m*s
@@ -511,7 +511,7 @@ template <typename Scalar, typename Scalar2, int M, int N>
 inline Matrix<Scalar, M, N> operator*(const Matrix<Scalar, M, N>& m,
                                       const Scalar2 s)
 {
-    return Matrix<Scalar, M, N>(m) *= s;
+    return Matrix<Scalar, M, N>(m) *= static_cast<Scalar>(s);
 }
 
 //! divide matrix by scalar: m/s
@@ -544,7 +544,7 @@ template <typename Scalar, int M, int N>
 inline Matrix<Scalar, M, N> normalize(const Matrix<Scalar, M, N>& m)
 {
     Scalar n = norm(m);
-    n = (n > std::numeric_limits<Scalar>::min()) ? 1.0 / n : 0.0;
+    n = (n > std::numeric_limits<Scalar>::min()) ? Scalar(1.0) / n : Scalar(0.0);
     return m * n;
 }
 
@@ -650,7 +650,7 @@ template <typename Scalar>
 Mat4<Scalar> perspective_matrix(Scalar fovy, Scalar aspect, Scalar zNear,
                                 Scalar zFar)
 {
-    Scalar t = Scalar(zNear) * tan(fovy * M_PI / 360.0);
+    Scalar t = Scalar(zNear) * tan(fovy * Scalar(M_PI / 360.0));
     Scalar b = -t;
     Scalar l = b * aspect;
     Scalar r = t * aspect;
@@ -664,7 +664,7 @@ template <typename Scalar>
 Mat4<Scalar> inverse_perspective_matrix(Scalar fovy, Scalar aspect,
                                         Scalar zNear, Scalar zFar)
 {
-    Scalar t = zNear * tan(fovy * M_PI / 360.0);
+    Scalar t = zNear * tan(fovy * Scalar(M_PI / 360.0));
     Scalar b = -t;
     Scalar l = b * aspect;
     Scalar r = t * aspect;
@@ -753,8 +753,8 @@ Mat4<Scalar> scaling_matrix(const Vector<Scalar, 3>& s)
 template <typename Scalar>
 Mat4<Scalar> rotation_matrix_x(Scalar angle)
 {
-    Scalar ca = cos(angle * (M_PI / 180.0));
-    Scalar sa = sin(angle * (M_PI / 180.0));
+    Scalar ca = cos(angle * Scalar(M_PI / 180.0));
+    Scalar sa = sin(angle * Scalar(M_PI / 180.0));
 
     Mat4<Scalar> m(0.0);
     m(0, 0) = 1.0;
@@ -771,8 +771,8 @@ Mat4<Scalar> rotation_matrix_x(Scalar angle)
 template <typename Scalar>
 Mat4<Scalar> rotation_matrix_y(Scalar angle)
 {
-    Scalar ca = cos(angle * (M_PI / 180.0));
-    Scalar sa = sin(angle * (M_PI / 180.0));
+    Scalar ca = cos(angle * Scalar(M_PI / 180.0));
+    Scalar sa = sin(angle * Scalar(M_PI / 180.0));
 
     Mat4<Scalar> m(0.0);
     m(0, 0) = ca;
@@ -789,8 +789,8 @@ Mat4<Scalar> rotation_matrix_y(Scalar angle)
 template <typename Scalar>
 Mat4<Scalar> rotation_matrix_z(Scalar angle)
 {
-    Scalar ca = cos(angle * (M_PI / 180.0));
-    Scalar sa = sin(angle * (M_PI / 180.0));
+    Scalar ca = cos(angle * Scalar(M_PI / 180.0));
+    Scalar sa = sin(angle * Scalar(M_PI / 180.0));
 
     Mat4<Scalar> m(0.0);
     m(0, 0) = ca;
@@ -808,7 +808,7 @@ template <typename Scalar>
 Mat4<Scalar> rotation_matrix(const Vector<Scalar, 3>& axis, Scalar angle)
 {
     Mat4<Scalar> m(Scalar(0));
-    Scalar a = angle * (M_PI / 180.0f);
+    Scalar a = angle * Scalar(M_PI / 180.0f);
     Scalar c = cosf(a);
     Scalar s = sinf(a);
     Scalar one_m_c = Scalar(1) - c;

--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1689,7 +1689,7 @@ public:
     //! returns end iterator for vertices
     VertexIterator vertices_end() const
     {
-        return VertexIterator(Vertex(vertices_size()), this);
+        return VertexIterator(Vertex(static_cast<IndexType>(vertices_size())), this);
     }
 
     //! returns vertex container for C++11 range-based for-loops
@@ -1707,7 +1707,7 @@ public:
     //! returns end iterator for halfedges
     HalfedgeIterator halfedges_end() const
     {
-        return HalfedgeIterator(Halfedge(halfedges_size()), this);
+        return HalfedgeIterator(Halfedge(static_cast<IndexType>(halfedges_size())), this);
     }
 
     //! returns halfedge container for C++11 range-based for-loops
@@ -1722,7 +1722,7 @@ public:
     //! returns end iterator for edges
     EdgeIterator edges_end() const
     {
-        return EdgeIterator(Edge(edges_size()), this);
+        return EdgeIterator(Edge(static_cast<IndexType>(edges_size())), this);
     }
 
     //! returns edge container for C++11 range-based for-loops
@@ -1749,7 +1749,7 @@ public:
     //! returns end iterator for faces
     FaceIterator faces_end() const
     {
-        return FaceIterator(Face(faces_size()), this);
+        return FaceIterator(Face(static_cast<IndexType>(faces_size())), this);
     }
 
     //! returns face container for C++11 range-based for-loops
@@ -1991,7 +1991,7 @@ public:
             throw AllocationException(what);
         }
         vprops_.push_back();
-        return Vertex(vertices_size() - 1);
+        return Vertex(static_cast<IndexType>(vertices_size()) - 1);
     }
 
     //! \brief Allocate a new edge, resize edge and halfedge properties accordingly.
@@ -2008,8 +2008,8 @@ public:
         hprops_.push_back();
         hprops_.push_back();
 
-        Halfedge h0(halfedges_size() - 2);
-        Halfedge h1(halfedges_size() - 1);
+        Halfedge h0(static_cast<IndexType>(halfedges_size()) - 2);
+        Halfedge h1(static_cast<IndexType>(halfedges_size()) - 1);
 
         return h0;
     }
@@ -2032,8 +2032,8 @@ public:
         hprops_.push_back();
         hprops_.push_back();
 
-        Halfedge h0(halfedges_size() - 2);
-        Halfedge h1(halfedges_size() - 1);
+        Halfedge h0(static_cast<IndexType>(halfedges_size()) - 2);
+        Halfedge h1(static_cast<IndexType>(halfedges_size()) - 1);
 
         set_vertex(h0, end);
         set_vertex(h1, start);
@@ -2052,7 +2052,7 @@ public:
         }
 
         fprops_.push_back();
-        return Face(faces_size() - 1);
+        return Face(static_cast<IndexType>(faces_size()) - 1);
     }
 
     //!@}

--- a/src/pmp/algorithms/BarycentricCoordinates.h
+++ b/src/pmp/algorithms/BarycentricCoordinates.h
@@ -13,7 +13,7 @@ const Vector<Scalar, 3> barycentric_coordinates(const Vector<Scalar, 3>& p,
                                                 const Vector<Scalar, 3>& v,
                                                 const Vector<Scalar, 3>& w)
 {
-    Vector<Scalar, 3> result(1.0 / 3.0); // default: barycenter
+    Vector<Scalar, 3> result(Scalar(1.0 / 3.0)); // default: barycenter
 
     Vector<Scalar, 3> vu = v - u, wu = w - u, pu = p - u;
 
@@ -55,9 +55,9 @@ const Vector<Scalar, 3> barycentric_coordinates(const Vector<Scalar, 3>& p,
         {
             if (1.0 + ax != 1.0)
             {
-                result[1] = 1.0 + (pu[1] * wu[2] - pu[2] * wu[1]) / nx - 1.0;
-                result[2] = 1.0 + (vu[1] * pu[2] - vu[2] * pu[1]) / nx - 1.0;
-                result[0] = 1.0 - result[1] - result[2];
+                result[1] = static_cast<Scalar>(1.0 + (pu[1] * wu[2] - pu[2] * wu[1]) / nx - 1.0);
+                result[2] = static_cast<Scalar>(1.0 + (vu[1] * pu[2] - vu[2] * pu[1]) / nx - 1.0);
+                result[0] = static_cast<Scalar>(1.0 - result[1] - result[2]);
             }
             break;
         }
@@ -66,9 +66,9 @@ const Vector<Scalar, 3> barycentric_coordinates(const Vector<Scalar, 3>& p,
         {
             if (1.0 + ay != 1.0)
             {
-                result[1] = 1.0 + (pu[2] * wu[0] - pu[0] * wu[2]) / ny - 1.0;
-                result[2] = 1.0 + (vu[2] * pu[0] - vu[0] * pu[2]) / ny - 1.0;
-                result[0] = 1.0 - result[1] - result[2];
+                result[1] = static_cast<Scalar>(1.0 + (pu[2] * wu[0] - pu[0] * wu[2]) / ny - 1.0);
+                result[2] = static_cast<Scalar>(1.0 + (vu[2] * pu[0] - vu[0] * pu[2]) / ny - 1.0);
+                result[0] = static_cast<Scalar>(1.0 - result[1] - result[2]);
             }
             break;
         }
@@ -77,9 +77,9 @@ const Vector<Scalar, 3> barycentric_coordinates(const Vector<Scalar, 3>& p,
         {
             if (1.0 + az != 1.0)
             {
-                result[1] = 1.0 + (pu[0] * wu[1] - pu[1] * wu[0]) / nz - 1.0;
-                result[2] = 1.0 + (vu[0] * pu[1] - vu[1] * pu[0]) / nz - 1.0;
-                result[0] = 1.0 - result[1] - result[2];
+                result[1] = static_cast<Scalar>(1.0 + (pu[0] * wu[1] - pu[1] * wu[0]) / nz - 1.0);
+                result[2] = static_cast<Scalar>(1.0 + (vu[0] * pu[1] - vu[1] * pu[0]) / nz - 1.0);
+                result[0] = static_cast<Scalar>(1.0 - result[1] - result[2]);
             }
             break;
         }

--- a/src/pmp/algorithms/DifferentialGeometry.h
+++ b/src/pmp/algorithms/DifferentialGeometry.h
@@ -12,16 +12,16 @@ namespace pmp {
 //! @{
 
 //! clamp cotangent values as if angles are in [3, 177]
-inline double clamp_cot(const double v)
+inline Scalar clamp_cot(const Scalar v)
 {
-    const double bound = 19.1; // 3 degrees
+    const Scalar bound = Scalar(19.1); // 3 degrees
     return (v < -bound ? -bound : (v > bound ? bound : v));
 }
 
 //! clamp cosine values as if angles are in [3, 177]
-inline double clamp_cos(const double v)
+inline Scalar clamp_cos(const Scalar v)
 {
-    const double bound = 0.9986; // 3 degrees
+    const Scalar bound = Scalar(0.9986); // 3 degrees
     return (v < -bound ? -bound : (v > bound ? bound : v));
 }
 

--- a/src/pmp/algorithms/NormalCone.h
+++ b/src/pmp/algorithms/NormalCone.h
@@ -46,7 +46,7 @@ public:
         // axes point in opposite directions
         else if (dp < -0.99999)
         {
-            angle_ = 2 * M_PI;
+            angle_ = Scalar(2 * M_PI);
         }
 
         else
@@ -55,10 +55,10 @@ public:
             Scalar center_angle = std::acos(dp);
             Scalar min_angle = std::min(-angle_, center_angle - nc.angle_);
             Scalar max_angle = std::max(angle_, center_angle + nc.angle_);
-            angle_ = 0.5 * (max_angle - min_angle);
+            angle_ = Scalar(0.5) * (max_angle - min_angle);
 
             // axis by SLERP
-            Scalar axis_angle = 0.5 * (min_angle + max_angle);
+            Scalar axis_angle = Scalar(0.5) * (min_angle + max_angle);
             center_normal_ =
                 ((center_normal_ * std::sin(center_angle - axis_angle) +
                   nc.center_normal_ * std::sin(axis_angle)) /

--- a/src/pmp/algorithms/SurfaceCurvature.h
+++ b/src/pmp/algorithms/SurfaceCurvature.h
@@ -34,7 +34,7 @@ public:
     //! return mean curvature
     Scalar mean_curvature(Vertex v) const
     {
-        return 0.5 * (min_curvature_[v] + max_curvature_[v]);
+        return Scalar(0.5) * (min_curvature_[v] + max_curvature_[v]);
     }
 
     //! return Gaussian curvature


### PR DESCRIPTION
Signed-off-by: Andrew Magill <AMagill@users.noreply.github.com>

# Description

Fixed MSVC implicit numeric conversion warnings in header files.

# Motivation

When this library is included in other MSVC projects, it was likely to produce unacceptable warnings.  These are disabled in the library's own build, but likely not in other projects using it.

# Benefits

No more warnings when including this library in other projects!

# Drawbacks

None.  Only changed implicit numeric conversions to explicit.

# Applicable Issues

None.
