### PR TITLE
Add missing std::array header

### DIFF
--- a/src/pmp/MatVec.h
+++ b/src/pmp/MatVec.h
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cassert>
 
+#include <array>
 #include <iostream>
 #include <limits>
 #include <initializer_list>


### PR DESCRIPTION
# Description

Add missing `#include <array>` header

# Motivation

Depending on what is included together with pmp headers, the build usually works, but not always. Since `std::array`s are used it's just better to have it explicitly included there.

Usage in line:
https://github.com/pmp-library/pmp-library/blob/0337edeb08bef59f2f57cc5c4f0f3d7a2056dbb7/src/pmp/MatVec.h#L322

# Benefits

Makes it build always

# Drawbacks

One extra `#include` in a header file

# Applicable Issues

None
