### PR TITLE
Fix transitive requirement for C++17

### DIFF
--- a/src/pmp/CMakeLists.txt
+++ b/src/pmp/CMakeLists.txt
@@ -25,9 +25,7 @@ if(NOT EMSCRIPTEN AND PMP_INSTALL)
     pmp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
                $<INSTALL_INTERFACE:include/>)
 
-  if(UNIX OR APPLE)
-    target_compile_options(pmp PUBLIC "-std=c++17")
-  endif()
+  target_compile_features(pmp PUBLIC cxx_std_17)
 
   install(
     TARGETS pmp


### PR DESCRIPTION
This sets the transitive requirements for the C++ standard according to [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html#requiring-language-standards) instead of hardcoded flags. This requirement applies on Windows OS too now.
