### PR TITLE
Support CMake build with vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_policy(SET CMP0048 NEW)
+cmake_policy(SET CMP0022 NEW)
 project(
   pmp-library
   VERSION 2.0.1
@@ -69,13 +70,23 @@ if(PMP_BUILD_VIS)
 endif(PMP_BUILD_VIS)
 
 # setup Eigen
-set(EIGEN_SOURCE_DIR "external/eigen")
-include_directories(${EIGEN_SOURCE_DIR})
+find_path(EIGEN3_INCLUDE_DIR "Eigen/Eigen")
+if(EIGEN3_INCLUDE_DIR)
+  include_directories(${EIGEN3_INCLUDE_DIR})
+else()
+  set(EIGEN_SOURCE_DIR "external/eigen")
+  include_directories(${EIGEN_SOURCE_DIR})
+endif()
 
 # setup PLY
-set(RPLY_SOURCE_DIR "external/rply")
-include_directories(${RPLY_SOURCE_DIR})
-add_subdirectory(${RPLY_SOURCE_DIR})
+find_package(rply REQUIRED)
+if(rply_FOUND)
+  link_libraries(rply::rply)
+else()
+  set(RPLY_SOURCE_DIR "external/rply")
+  include_directories(${RPLY_SOURCE_DIR})
+  add_subdirectory(${RPLY_SOURCE_DIR})
+endif()
 
 include(AddFileDependencies)
 include_directories(${PROJECT_SOURCE_DIR}/src/)

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -87,6 +87,11 @@ else()
   if(NOT WIN32)
     add_executable(mconvert mconvert.cpp)
     target_link_libraries(mconvert pmp)
+    if(PMP_INSTALL)
+      install(
+        TARGETS mconvert
+        DESTINATION bin)
+    endif()
   endif()
 
   if(OpenGL_FOUND AND PMP_BUILD_VIS)
@@ -117,6 +122,12 @@ else()
     add_executable(mpview mpview.cpp MeshProcessingViewer.cpp
                           MeshProcessingViewer.h)
     target_link_libraries(mpview pmp_vis)
+
+    if(PMP_INSTALL)
+      install(
+        TARGETS mview curview subdiv smoothing fairing parameterization decimation remeshing mpview
+        DESTINATION bin)
+    endif()
   endif()
 
 endif()

--- a/src/pmp/CMakeLists.txt
+++ b/src/pmp/CMakeLists.txt
@@ -1,10 +1,13 @@
 file(GLOB SOURCES ./*.cpp)
 file(GLOB HEADERS ./*.h)
+if(NOT TARGET rply::rply)
+  list(APPEND RPLY_OBJS $<TARGET_OBJECTS:rply>)
+endif()
 
 if(EMSCRIPTEN)
-  add_library(pmp STATIC ${SOURCES} ${HEADERS} $<TARGET_OBJECTS:rply>)
+  add_library(pmp STATIC ${SOURCES} ${HEADERS} ${RPLY_OBJS})
 else()
-  add_library(pmp SHARED ${SOURCES} ${HEADERS} $<TARGET_OBJECTS:rply>)
+  add_library(pmp SHARED ${SOURCES} ${HEADERS} ${RPLY_OBJS})
   set_property(TARGET pmp PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 


### PR DESCRIPTION
# Description

* Find existing libraries from build environment
* Install tools if `PMP_INSTALL` is set

# Motivation

There are some requests for this project in the https://github.com/microsoft/vcpkg.
I'd like to add some build scripts in https://github.com/microsoft/vcpkg/pull/27657

# Benefits

Ease of integration with existing packages in the vcpkg

# Drawbacks

More conditions in CMakeLists.txt. (see the changes)

# Applicable Issues

* I saw #106 #86. If the decision is still valid, I will drop the changes.
   I'd like to know if the local-installed `RPLY` is the same case.
