### PR TITLE
Face property propagation RFC

### DIFF
--- a/src/pmp/Properties.h
+++ b/src/pmp/Properties.h
@@ -39,6 +39,9 @@ public:
     //! Let two elements swap their storage place.
     virtual void swap(size_t i0, size_t i1) = 0;
 
+    //! Copy source to destination.
+    virtual void copy(size_t isource, size_t idestination) = 0;
+
     //! Return a deep copy of self.
     virtual BasePropertyArray* clone() const = 0;
 
@@ -79,6 +82,11 @@ public:
         T d(data_[i0]);
         data_[i0] = data_[i1];
         data_[i1] = d;
+    }
+
+    void copy(size_t isource, size_t idestination) override
+    {
+        data_[idestination] = data_[isource];
     }
 
     BasePropertyArray* clone() const override
@@ -342,6 +350,13 @@ public:
     {
         for (auto parray : parrays_)
             parray->swap(i0, i1);
+    }
+
+    // copy elements isource to idestination in all arrays
+    void copy(size_t isource, size_t idestination)
+    {
+        for (auto parray : parrays_)
+            parray->copy(isource, idestination);
     }
 
 private:

--- a/src/pmp/SurfaceMesh.cpp
+++ b/src/pmp/SurfaceMesh.cpp
@@ -496,7 +496,7 @@ void SurfaceMesh::split(Face f, Vertex v)
     {
         Halfedge hnext = next_halfedge(h);
 
-        Face fnew = new_face();
+        Face fnew = new_face(f);
         set_halfedge(fnew, h);
 
         Halfedge hnew = new_edge(to_vertex(h), v);
@@ -548,7 +548,7 @@ Halfedge SurfaceMesh::split(Edge e, Vertex v)
         Halfedge e0 = new_edge(v, v1);
         Halfedge t0 = opposite_halfedge(e0);
 
-        Face f1 = new_face();
+        Face f1 = new_face(f0);
         set_halfedge(f0, h0);
         set_halfedge(f1, h2);
 
@@ -585,7 +585,7 @@ Halfedge SurfaceMesh::split(Edge e, Vertex v)
         Halfedge e2 = new_edge(v, v3);
         Halfedge t2 = opposite_halfedge(e2);
 
-        Face f2 = new_face();
+        Face f2 = new_face(f3);
         set_halfedge(f2, o1);
         set_halfedge(f3, o0);
 
@@ -686,7 +686,7 @@ Halfedge SurfaceMesh::insert_edge(Halfedge h0, Halfedge h1)
     Halfedge h5 = opposite_halfedge(h4);
 
     Face f0 = face(h0);
-    Face f1 = new_face();
+    Face f1 = new_face(f0);
 
     set_halfedge(f0, h0);
     set_halfedge(f1, h1);

--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -2028,6 +2028,17 @@ public:
         return Face(static_cast<IndexType>(faces_size()) - 1);
     }
 
+    //! \brief Allocate a new face, resize face properties accordingly, propagate properties.
+    //! \throw AllocationException in case of failure to allocate a new face.
+    Face new_face(Face f_to_copy_properties)
+    {
+        Face thisface = new_face();
+
+        fprops_.copy( f_to_copy_properties.idx(), thisface.idx() );
+
+        return thisface;
+    }
+
     //!@}
 
 private:


### PR DESCRIPTION
# Description

Propagate face properties when splitting a face.  This is just a quick stab at this.  I took this on as much to learn more about PMP as to provide  real solution to the problem.

# Motivation

A mesh with face properties should make some attempt to pass those properties to new entities as the mesh is modified.

# Benefits

Propagates properties to new faces where appropriate

# Drawbacks

Some users may not expect this to happen.  Other users may want a more sophisticated capability where (for example) math is done during the split process.

# Applicable Issues

141
