### PR TITLE
Make pmp and pmp_vis usable as a git submodule / cmake subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ if(PMP_BUILD_VIS)
 
   # setup STB Image (place *before* GLFW since GLFW has an old copy of
   # stb_image_write.h)
-  include_directories(${STBI_SOURCE_DIR})
   add_subdirectory(${STBI_SOURCE_DIR})
 
   # Building only the GLFW lib
@@ -54,27 +53,18 @@ if(PMP_BUILD_VIS)
   if(NOT EMSCRIPTEN)
     add_subdirectory(${GLFW_SOURCE_DIR} ${GLEW_SOURCE_DIR})
 
-    include_directories(${GLFW_SOURCE_DIR}/include ${GLFW_SOURCE_DIR}/deps
-                        ${GLEW_SOURCE_DIR}/include)
-
     add_definitions(-DGLEW_STATIC)
     add_library(glew STATIC ${GLEW_SOURCE_DIR}/src/glew.c
                             ${GLEW_SOURCE_DIR}/include)
     set_property(TARGET glew PROPERTY POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(glew PUBLIC ${GLEW_SOURCE_DIR}/include
+                                           ${GLFW_SOURCE_DIR}/include)
     target_link_libraries(glew ${GLFW_LIBRARIES})
   endif()
 
   # setup IMGUI
-  include_directories(${IMGUI_SOURCE_DIR})
   add_subdirectory(${IMGUI_SOURCE_DIR})
 endif(PMP_BUILD_VIS)
-
-# setup Eigen
-set(EIGEN_SOURCE_DIR "external/eigen")
-include_directories(${EIGEN_SOURCE_DIR})
-
-include(AddFileDependencies)
-include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 # setup for code coverage testing
 if(CMAKE_BUILD_TYPE STREQUAL "Debug"

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -5,5 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(imgui STATIC ${SOURCES} ${HEADERS})
-target_link_libraries(imgui ${CMAKE_DL_LIBS})
+#TODO: instead of linking glew to get the glfw includ dir, maybe just use a global variable?
+target_link_libraries(imgui ${CMAKE_DL_LIBS} glew)
+target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_property(TARGET imgui PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/external/stb_image/CMakeLists.txt
+++ b/external/stb_image/CMakeLists.txt
@@ -6,5 +6,5 @@ if(UNIX)
 endif()
 
 add_library(stb_image STATIC ${HDRS} ${SRCS})
+target_include_directories(stb_image PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(stb_image PROPERTIES POSITION_INDEPENDENT_CODE ON)
-

--- a/src/pmp/CMakeLists.txt
+++ b/src/pmp/CMakeLists.txt
@@ -22,8 +22,10 @@ endif()
 if(NOT EMSCRIPTEN AND PMP_INSTALL)
 
   target_include_directories(
-    pmp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
-               $<INSTALL_INTERFACE:include/>)
+      pmp PUBLIC 
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/eigen>
+      $<INSTALL_INTERFACE:include/>)
 
   target_compile_features(pmp PUBLIC cxx_std_17)
 
@@ -37,7 +39,8 @@ if(NOT EMSCRIPTEN AND PMP_INSTALL)
     DESTINATION include)
 
   install(FILES ${HEADERS} DESTINATION include/pmp/)
-
+else()
+    target_include_directories(pmp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../ ../../external/eigen)
 endif()
 
 if(PMP_BUILD_VIS)


### PR DESCRIPTION
# Description

Replaced all `include_directories` calls in the cmake files with `target_include_directories` so that the targets can properly be used with cmake `add_subdirectory` and properly propagate include directories. This allows to you add pmp as a git submodule to your project. I tested my changes on `osx`, `Ubuntu 22.04` and `Windows 11` for both local and install builds.

# Motivation

Because using pmp as a git submodule/cmake subdirectory makes it a lot more versatile.

# Benefits

See above.

# Drawbacks

N/A

# Applicable Issues

N/A
