### PR TITLE
Check IOFlags::use_halfedge_texcoords when writing faces to obj files.

### DIFF
--- a/src/pmp/io/write_obj.cpp
+++ b/src/pmp/io/write_obj.cpp
@@ -44,7 +44,9 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
 
     // write texture coordinates
     auto tex_coords = mesh.get_halfedge_property<TexCoord>("h:tex");
-    if (tex_coords && flags.use_halfedge_texcoords)
+    bool write_texcoords = tex_coords && flags.use_halfedge_texcoords;
+
+    if (write_texcoords)
     {
         if (mesh.n_halfedges() > uint_max)
             throw InvalidInputException(
@@ -66,7 +68,7 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
         for (auto v : mesh.vertices(f))
         {
             auto idx = v.idx() + 1;
-            if (tex_coords)
+            if (write_texcoords)
             {
                 // write vertex index, texCoord index and normal index
                 fprintf(out, " %d/%d/%d", (uint32_t)idx,

--- a/tests/io_test.cpp
+++ b/tests/io_test.cpp
@@ -17,7 +17,7 @@ TEST_F(IOTest, obj_io)
 {
     add_triangle();
     vertex_normals(mesh);
-    mesh.add_halfedge_property<TexCoord>("h:texcoord", TexCoord(0, 0));
+    mesh.add_halfedge_property<TexCoord>("h:tex", TexCoord(0, 0));
     write(mesh, "test.obj");
     mesh.clear();
     EXPECT_TRUE(mesh.is_empty());


### PR DESCRIPTION
# Description

Do not write halfedge texcoords to the "f /// /// ///" lines of obj files, if IOFlags::use_halfedge_texcoords is false.
Fix corresponding unit test. 

# Motivation

When writing a SurfaceMesh with halfedge texture coordinates to an .obj file, the corresponding "vt u_coord v_coord" lines are not written to the .obj file, if IOFlags::use_halfedge_texcoords is set to false. 

However, when writing the corresponding "f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3" lines, the halfedge texture coordinates are included. 

This leads to pmp crashing when trying to read the resulting written obj. 
This behavior was not detected in the `IOTest, obj_io` test

https://github.com/pmp-library/pmp-library/blob/e20e5f175216ed04a18b308088e466ebf2b33db4/tests/io_test.cpp#L16-L27

because the name of the halfedge texcoord property used in the readers/writers and in the rest of PMP is "h:tex", and not "h:texcoord". So this PR modifies the unit test accordingly.

# Benefits

Fixes 
```c++
pmp::write(mesh, "foo.obj");
pmp::read(mesh, "foo.obj");
```

crashing, when the involved mesh has halfedge texture coordinates and IOFlags::use_texture_coordinates is set to false.

# Drawbacks

None

# Applicable Issues

https://github.com/pmp-library/pmp-library/issues/188