### PR TITLE
OFF import fixes

### DIFF
--- a/src/pmp/io/read_off.cpp
+++ b/src/pmp/io/read_off.cpp
@@ -131,10 +131,8 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
     // #Vertices, #Faces, #Edges
     auto items = sscanf(lp, "%ld %ld %ld\n", &nv, &nf, &ne);
 
-    if (items < 3 || nv < 1 || nf < 1 || ne < 0) {
-        std::cerr << "Invalid header" << std::endl;
-        return;
-    }
+    if (items < 3 || nv < 1 || nf < 1 || ne < 0)
+        throw IOException("Failed to parse OFF header");
 
     mesh.reserve(nv, std::max(3 * nv, ne), nf);
 
@@ -203,10 +201,8 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
         // #vertices
         items = sscanf(lp, "%ld%n", &nv, &nc);
         assert(items == 1);
-        if (nv < 1) {
-            std::cerr << "Invalid index count" << std::endl;
-            return;
-        }
+        if (nv < 1)
+            throw IOException("Invalid index count");
         vertices.resize(nv);
         lp += nc;
 
@@ -215,10 +211,8 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
         {
             items = sscanf(lp, "%ld%n", &idx, &nc);
             assert(items == 1);
-            if (idx < 0) {
-                std::cerr << "Invalid index" << std::endl;
-                return;
-            }
+            if (idx < 0)
+                throw IOException("Invalid index");
             vertices[j] = Vertex(idx);
             lp += nc;
         }

--- a/src/pmp/io/read_off.cpp
+++ b/src/pmp/io/read_off.cpp
@@ -98,6 +98,7 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
                     const bool has_texcoords, const bool has_colors)
 {
     std::array<char, 1000> line;
+    char *lp;
     int nc;
     unsigned int i, j, idx;
     unsigned int nv, nf, ne;
@@ -115,17 +116,24 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
     if (has_colors)
         colors = mesh.vertex_property<Color>("v:color");
 
+    // read line, but skip comment lines
+    do {
+        lp = fgets(line.data(), 1000, in);
+    } while(lp && lp[0] == '#');
+
     // #Vertices, #Faces, #Edges
     [[maybe_unused]] auto items =
-        fscanf(in, "%d %d %d\n", (int*)&nv, (int*)&nf, (int*)&ne);
+        sscanf(lp, "%d %d %d\n", (int*)&nv, (int*)&nf, (int*)&ne);
 
     mesh.reserve(nv, std::max(3 * nv, ne), nf);
 
     // read vertices: pos [normal] [color] [texcoord]
     for (i = 0; i < nv && !feof(in); ++i)
     {
-        // read line
-        auto lp = fgets(line.data(), 1000, in);
+        // read line, but skip comment lines
+        do {
+            lp = fgets(line.data(), 1000, in);
+        } while(lp && lp[0] == '#');
         lp = line.data();
 
         // position
@@ -175,8 +183,10 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
     std::vector<Vertex> vertices;
     for (i = 0; i < nf; ++i)
     {
-        // read line
-        auto lp = fgets(line.data(), 1000, in);
+        // read line, but skip comment lines
+        do {
+            lp = fgets(line.data(), 1000, in);
+        } while(lp && lp[0] == '#');
         lp = line.data();
 
         // #vertices

--- a/src/pmp/io/read_off.cpp
+++ b/src/pmp/io/read_off.cpp
@@ -119,7 +119,7 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
     // read line, but skip comment lines
     do {
         lp = fgets(line.data(), 1000, in);
-    } while(lp && lp[0] == '#');
+    } while(lp && (lp[0] == '#' || lp[0] == '\n'));
 
     // #Vertices, #Faces, #Edges
     auto items = sscanf(lp, "%ld %ld %ld\n", &nv, &nf, &ne);
@@ -137,7 +137,7 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
         // read line, but skip comment lines
         do {
             lp = fgets(line.data(), 1000, in);
-        } while(lp && lp[0] == '#');
+        } while(lp && (lp[0] == '#' || lp[0] == '\n'));
         lp = line.data();
 
         // position
@@ -190,7 +190,7 @@ void read_off_ascii(SurfaceMesh& mesh, FILE* in, const bool has_normals,
         // read line, but skip comment lines
         do {
             lp = fgets(line.data(), 1000, in);
-        } while(lp && lp[0] == '#');
+        } while(lp && (lp[0] == '#' || lp[0] == '\n'));
         lp = line.data();
 
         // #vertices


### PR DESCRIPTION
# Description

This fixes crashes importing some files that include comment, like from there:
https://people.sc.fsu.edu/~jburkardt/data/off/off.html

Maybe some of the asserts should also be proper error checking as they get removed in default build?

# Motivation

I needed binary OFF files to test the OFF import in OpenSCAD, but couldn't find any, and trying to convert some with `mconvert` resulted in bad_alloc errors.

# Benefits

Avoid crashes.

# Drawbacks

Less crashes to have fun debugging?