### PR TITLE
New Feature: Wavefront Object (.obj) vertex color support

### DIFF
--- a/data/obj/cube_vc_inline.obj
+++ b/data/obj/cube_vc_inline.obj
@@ -1,0 +1,26 @@
+# File exported by Houdini 20.0.506 (www.sidefx.com)
+# 8 points
+# 24 vertices
+# 6 primitives
+# Bounds: [-0.5, -0.5, -0.5] to [0.5, 0.5, 0.5]
+
+g 
+
+# Vertex colors are in line with the vertex location!
+v 0.5 -0.5 0.5 1 0 1   # Magenta
+v -0.5 -0.5 0.5 0 0 1  # Blue
+v 0.5 0.5 0.5 1 1 1    # White
+v -0.5 0.5 0.5 0 1 1   # Cyan
+v -0.5 -0.5 -0.5 0 0 0 # Black
+v 0.5 -0.5 -0.5 1 0 0  # Red
+v -0.5 0.5 -0.5 0 1 0  # Green
+v 0.5 0.5 -0.5 1 1 0   # Yellow
+
+g 
+
+f 1 3 4 2
+f 5 7 8 6
+f 7 4 3 8
+f 6 1 2 5
+f 6 8 3 1
+f 2 4 7 5

--- a/data/obj/cube_vc_zbrush.obj
+++ b/data/obj/cube_vc_zbrush.obj
@@ -1,0 +1,27 @@
+g 
+
+v 0.5 -0.5 0.5a
+v -0.5 -0.5 0.5
+v 0.5 0.5 0.5
+v -0.5 0.5 0.5
+v -0.5 -0.5 -0.5
+v 0.5 -0.5 -0.5
+v -0.5 0.5 -0.5
+v 0.5 0.5 -0.5
+
+# Vertex colors are below! Definitely harder to parse for someone reading the file,
+# But maybe easier for a computer shoving the data into a GPU?
+
+# The following MRGB block contains ZBrush Vertex Color (Polypaint) and 
+# masking output as 4 hexadecimal values per vertex. The vertex color format 
+# is MMRRGGBB with up to 64 entries per MRGB line.
+#MRGB ffff00ffff0000ffffffffffff00ffffff000000ffff0000ff00ff00ffffff00
+
+g 
+
+f 1 3 4 2
+f 5 7 8 6
+f 7 4 3 8
+f 6 1 2 5
+f 6 8 3 1
+f 2 4 7 5

--- a/src/pmp/io/read_obj.cpp
+++ b/src/pmp/io/read_obj.cpp
@@ -8,8 +8,10 @@ namespace pmp {
 
 void read_obj(SurfaceMesh& mesh, const std::filesystem::path& file)
 {
-    std::array<char, 200> s;
-    float x, y, z;
+    std::array<char, 600> s;
+    float x, y, z, r, g, b;
+    uint vert_count = 0;
+    Vertex v;
     std::vector<Vertex> vertices;
     std::vector<TexCoord> all_tex_coords; //individual texture coordinates
     std::vector<int>
@@ -17,6 +19,8 @@ void read_obj(SurfaceMesh& mesh, const std::filesystem::path& file)
     HalfedgeProperty<TexCoord> tex_coords =
         mesh.halfedge_property<TexCoord>("h:tex");
     bool with_tex_coord = false;
+    VertexProperty<Color> colors;
+    bool with_vert_colors = false;
 
     // open file (in ASCII mode)
     FILE* in = fopen(file.string().c_str(), "r");
@@ -24,21 +28,80 @@ void read_obj(SurfaceMesh& mesh, const std::filesystem::path& file)
         throw IOException("Failed to open file: " + file.string());
 
     // clear line once
-    memset(s.data(), 0, 200);
+    memset(s.data(), 0, 600);
 
     // parse line by line (currently only supports vertex positions & faces
-    while (in && !feof(in) && fgets(s.data(), 200, in))
+    while (in && !feof(in) && fgets(s.data(), 600, in))
     {
         // comment
-        if (s[0] == '#' || isspace(s[0]))
+        if ((s[0] == '#' && s[1] != 'M') || isspace(s[0]))
             continue;
 
         // vertex
         else if (strncmp(s.data(), "v ", 2) == 0)
         {
-            if (sscanf(s.data(), "v %f %f %f", &x, &y, &z))
+            if (sscanf(s.data(), "v %f %f %f %f %f %f", &x, &y, &z, &r, &g, &b))
+            {
+                if (!with_vert_colors)
+                {
+                    colors = mesh.vertex_property<Color>("v:color");
+                    with_vert_colors = true;
+                }
+                v = mesh.add_vertex(Point(x, y, z));
+                colors[v] = Color(r, g, b);
+            }
+            else if (sscanf(s.data(), "v %f %f %f", &x, &y, &z))
             {
                 mesh.add_vertex(Point(x, y, z));
+            }
+        }
+
+        // zbrush vertex color
+        else if (strncmp(s.data(), "#MRGB ", 6) == 0)
+        {
+            if (!with_vert_colors)
+            {
+                colors = mesh.vertex_property<Color>("v:color");
+                with_vert_colors = true;
+            }
+            int colors_in_line = (std::strlen(s.data()) - 7) / 8;
+            for (int i = 0; i < colors_in_line; i++)
+            {
+                std::cout << vert_count << std::endl;
+                // For these purposes, mask is ignored
+                std::stringstream red, green, blue;
+                int red_of_255, green_of_255, blue_of_255;
+
+                // Read hex codes into string stream
+                red << s[i * 8 + 8] << s[i * 8 + 9];
+                green << s[i * 8 + 10] << s[i * 8 + 11];
+                blue << s[i * 8 + 12] << s[i * 8 + 13];
+
+                // convert string stream into int
+                red >> std::hex >> red_of_255;
+                green >> std::hex >> green_of_255;
+                blue >> std::hex >> blue_of_255;
+
+                // convert 1 - 255 int scale to 0-1 float scale
+                r = red_of_255 / 255;
+                g = green_of_255 / 255;
+                b = blue_of_255 / 255;
+
+                // So horribly slow, if possible replace with direct index access
+                for (Vertex vi : mesh.vertices())
+                {
+                    if (vi.idx() == vert_count)
+                    {
+                        v = vi;
+                        break;
+                    }
+                }
+                colors[v] = Color(r, g, b);
+                vert_count++;
+
+                red.clear();
+                green.clear();
+                blue.clear();
             }
         }
 
@@ -172,6 +235,11 @@ void read_obj(SurfaceMesh& mesh, const std::filesystem::path& file)
     if (!with_tex_coord)
     {
         mesh.remove_halfedge_property(tex_coords);
+    }
+
+    if (!with_vert_colors)
+    {
+        mesh.remove_vertex_property(colors);
     }
 
     fclose(in);

--- a/src/pmp/io/write_obj.cpp
+++ b/src/pmp/io/write_obj.cpp
@@ -14,6 +14,15 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
     if (!out)
         throw IOException("Failed to open file: " + file.string());
 
+    bool has_colors = false;
+
+    auto colors = mesh.get_vertex_property<Color>("v:color");
+
+    if (colors)
+    {
+        has_colors = true;
+    }
+
     // check if we can write the mesh using 32-bit indices
     const auto uint_max = std::numeric_limits<uint32_t>::max();
     if (mesh.n_vertices() > uint_max)
@@ -28,7 +37,15 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
     for (auto v : mesh.vertices())
     {
         const Point& p = points[v];
-        fprintf(out, "v %.10f %.10f %.10f\n", p[0], p[1], p[2]);
+        fprintf(out, "v %.10f %.10f %.10f", p[0], p[1], p[2]);
+
+        if (has_colors)
+        {
+            const Color& c = colors[v];
+            fprintf(out, " %.10f %.10f %.10f", c[0], c[1], c[2]);
+        }
+
+        fprintf(out, "\n");
     }
 
     // write normals

--- a/tests/io_test.cpp
+++ b/tests/io_test.cpp
@@ -18,12 +18,21 @@ TEST_F(IOTest, obj_io)
     add_triangle();
     vertex_normals(mesh);
     mesh.add_halfedge_property<TexCoord>("h:tex", TexCoord(0, 0));
+    mesh.add_vertex_property<Color>("v:color", Color(0, 0, 0));
     write(mesh, "test.obj");
     mesh.clear();
     EXPECT_TRUE(mesh.is_empty());
     read(mesh, "test.obj");
     EXPECT_EQ(mesh.n_vertices(), size_t(3));
     EXPECT_EQ(mesh.n_faces(), size_t(1));
+
+    read(mesh, "data/obj/cube_vc_inline.obj");
+    EXPECT_NO_THROW(mesh.get_vertex_property<Color>("v:color"));
+    mesh.clear();
+
+    read(mesh, "data/obj/cube_vc_zbrush.obj");
+    EXPECT_NO_THROW(mesh.get_vertex_property<Color>("v:color"));
+    mesh.clear();
 }
 
 TEST_F(IOTest, off_io)


### PR DESCRIPTION
# Description

Implementation of reading vertex colors for the Wavefront Object (.obj) file format using two common methods:
* inline with the point location in `v x y z r g b` format
* A method used by Z-Brush using a block of MRGB values in hexidecimal format

Implementation of writing vertex colors using `v x y z r g b` format.

# Motivation

I've been working on some tools to validate .obj files that are exported from Houdini and Z-Brush that include vertex color, and needed to be able to read vertex color as exported by those programs. 

#  Benefits

Vertex colors generated by many Digital Content Creation tools including Houdini and Z-Brush can now be read and processed in pmp-library

# Drawbacks

There is no official support for vertex colors in the (Wavefront Object file specification)[https://www.fileformat.info/format/wavefrontobj/egff.htm], so this is technically implementing features that is not a part of the official specification, however many modern computer graphics tools do read and write vertex colors for obj files in this way. 