### PR TITLE
Bounding box min/max methods are const

### DIFF
--- a/src/pmp/bounding_box.h
+++ b/src/pmp/bounding_box.h
@@ -49,10 +49,10 @@ public:
     }
 
     //! Get min point.
-    Point& min() { return min_; }
+    const Point& min() const { return min_; }
 
     //! Get max point.
-    Point& max() { return max_; }
+    const Point& max() const { return max_; }
 
     //! Get center point.
     Point center() const { return 0.5f * (min_ + max_); }


### PR DESCRIPTION
They also return const ref, hinting that modifying these values is a bad idea.

This change also enables retrieving these values from a bounding box which itself is const.

# Description
# Motivation
# Benefits

Just a small improvement to have to avoid const_cast

# Drawbacks

Can't see any, these values should be readonly anyway.

# Applicable Issues

N/A
