### PR TITLE
Performance Improvement: Curvature analysis, splitting up eigen matrix multiply dramatically improved performance.

### DIFF
--- a/src/pmp/algorithms/curvature.cpp
+++ b/src/pmp/algorithms/curvature.cpp
@@ -329,8 +329,8 @@ void CurvatureAnalyzer::smooth_curvatures(unsigned int iterations)
     // normalize each row by sum of weights
     // scale by 0.5 to make it more robust
     // multiply by -1 to make it neg. definite again
-    DiagonalMatrix D = L.diagonal().asDiagonal().inverse();
-    L = -0.5 * D * L;
+    DiagonalMatrix D = -0.5 * L.diagonal().asDiagonal().inverse();
+    L = D * L;
 
     // copy vertex curvatures to matrix
     const int n = mesh_.n_vertices();


### PR DESCRIPTION
On an MVSC (visual studio 2022) build of pmp, when doing some profiling of adaptive remeshing I found the line "L = -0.5 * D * L" in curvature.cpp was taking 2.5 minutes for a 400,000 vertex mesh (Most of the algorithm's runtime). 

Rearranging the statement to move the "-0.5 * " to the line above caused the statement to only take ~25 ms.

My hypothesis is that this rearrangement caused eigen to use an optimised templated specialisation for Diagonal * Sparse, which it was previously missing.

I haven't tested this with any other compilers.