### PR TITLE
support '\t' separator between vertex in obj file

### DIFF
--- a/src/pmp/io/read_obj.cpp
+++ b/src/pmp/io/read_obj.cpp
@@ -81,9 +81,9 @@ void read_obj(SurfaceMesh& mesh, const std::filesystem::path& file)
 
                 // overwrite next separator
 
-                // skip '/', '\n', ' ', '\0', '\r' <-- don't forget Windows
+                // skip '/', '\n', ' ', '\0', '\t', '\r' <-- don't forget Windows
                 while (*p1 != '/' && *p1 != '\r' && *p1 != '\n' && *p1 != ' ' &&
-                       *p1 != '\0')
+                       *p1 != '\0' && *p1 != '\t')
                     ++p1;
 
                 // detect end of vertex


### PR DESCRIPTION
# Description

support '\t' separator between vertex of f-line in obj file, e.g.  “f 1\t2\t3\n"

# Motivation

encounter an obj file, its face line has '\t' between vertex, which leads to pmp assert failure.

# Benefits

make pmp support '\t' separator between vertex of f-line in obj file

# Drawbacks

None AFAIK

# Applicable Issues

None AFAIK
