### PR TITLE
Convert framebuf and window width to float before computing scaling_

### DIFF
--- a/src/pmp/visualization/window.cpp
+++ b/src/pmp/visualization/window.cpp
@@ -105,7 +105,8 @@ Window::Window(const char* title, int width, int height, bool showgui)
     glfwGetFramebufferSize(window_, &framebuffer_width, &framebuffer_height);
     width_ = framebuffer_width;
     height_ = framebuffer_height;
-    scaling_ = framebuffer_width / window_width;
+    scaling_ = static_cast<float>(framebuffer_width) /
+               static_cast<float>(window_width);
     if (scaling_ != 1)
         std::cout << "highDPI scaling: " << scaling_ << std::endl;
 


### PR DESCRIPTION
# Description

Convert framebuffer and window width to float before computing `scaling_`. 

# Motivation

This allows to handle non-integer content scales, which can occur e.g. on mobile devices:

<img width="214" alt="non-integer-device-pixel-ratio" src="https://github.com/user-attachments/assets/987ca3c5-c552-45d1-b66c-5badd4e874c3" />

# Applicable Issues

#222
