### PR TITLE
New feature: Custom Remeshing function implementation

### DIFF
--- a/src/pmp/algorithms/remeshing.h
+++ b/src/pmp/algorithms/remeshing.h
@@ -40,4 +40,9 @@ void adaptive_remeshing(SurfaceMesh& mesh, Scalar min_edge_length,
                         unsigned int iterations = 10,
                         bool use_projection = true);
 
+
+void custom_remeshing(SurfaceMesh& mesh, std::vector<double>& target_edge_lengths,
+                        unsigned int iterations = 10,
+                        bool use_projection = true);
+
 } // namespace pmp


### PR DESCRIPTION
# Description

The current implementation of remeshing algorithm exposes a uniform remesh with target edge length and an adaptive remeshing, 
which sets an edge length in fuction of the curvature of the surface. The computation of curvature values and is internal to the adaptive_remesh call,
but the logics needed to convert the curvature scalar field into adaptive edge lengths is already part of the code, the only missing thing was a way to access it in a direct way.

Details of the changes:
- Implemented a new fuction for custom_remeshing;
- In line with the current procedure withl bool uniform_, I added a bool custom_vertex_edgeLengths_ class member that is set true from custom_remeshing. 
- Follow the conditionals in Remeshing::preprocessing()to select which of the three preprocessing to do;
- custom_remeshing preprocessing consists simply into passing the input spalar field to v_sizing;
- Added new call to header;

# Motivation
In my project I met the need to generate remeshing that adapts to scalar fields other than curvature. 
I have reached my objective providing a direct access to the edge splitting functions, by passing any scalar field 
mapped on vertices to a new remesh fuction that accepts this as input.
In the image below, a custom remeshing based on a geodesic distance field build based on the boundary curve of the surface.
![image](https://github.com/user-attachments/assets/36942a56-c295-4b49-bc5b-b6dfeb23f1e4)

# Benefits

As said in the description, 
this method exposes the already present adaptive remesh logics to multiple uses. 
It should be included to give access to all users to a remeshing that adapts to a customised scalar field, 
which can be representative of multiple quatitative or qualitative aspects linked with the geometry or its application.

# Drawbacks

[What are the potential drawbacks or side-effects?]

# Applicable Issues

Adaptive remeshing based on any criteria the user decides.
