### PR TITLE
Add GLAD_SOURCE_DIR/include to PUBLIC include directories of pmp_vis 

### DIFF
--- a/src/pmp/visualization/CMakeLists.txt
+++ b/src/pmp/visualization/CMakeLists.txt
@@ -18,7 +18,8 @@ else()
     add_library(pmp_vis STATIC ${SRCS} ${HDRS})
     target_include_directories(
       pmp_vis PRIVATE ${PROJECT_SOURCE_DIR}/${STB_IMAGE_WRITE_SOURCE_DIR}
-                      ${PROJECT_SOURCE_DIR}/${STB_IMAGE_SOURCE_DIR})
+                      ${PROJECT_SOURCE_DIR}/${STB_IMAGE_SOURCE_DIR}
+              PUBLIC  ${PROJECT_SOURCE_DIR}/${GLAD_SOURCE_DIR}/include)
     target_link_libraries(
       pmp_vis
       pmp


### PR DESCRIPTION
# Description

Adds a public include directory for GLAD to the pmp_vis library.

# Motivation

When using latest pmp as an external dependency (e.g. via CMake's FetchContent) and creating a small application:


`src/main.cpp`:
```
#include <pmp/visualization/mesh_viewer.h>

int main(int argc, char** argv)
{
    pmp::MeshViewer viewer("Hi", 800, 600);
    return viewer.run();
}
```


`CMakeLists.txt`:
```
cmake_minimum_required(VERSION 3.16.0)
project(myproject)

include(FetchContent)

set(PMP_BUILD_EXAMPLES OFF CACHE BOOL "")
set(PMP_BUILD_TEST OFF CACHE BOOL "")
set(PMP_BUILD_DOCS OFF CACHE BOOL "")

FetchContent_Declare(pmp
                     GIT_REPOSITORY https://github.com/pmp-library/pmp-library
                     GIT_TAG 63397d8dbb4e692e20a2baa3b1eda700a5ef0454)
FetchContent_MakeAvailable(pmp)


add_subdirectory(src)
```

the build fails with

```
[...]/pmp/visualization/gl.h:14:10: fatal error: 'glad/gl.h' file not found
#include <glad/gl.h>
         ^~~~~~~~~~~
1 error generated.
```

I think this used to work previously with GLEW because it was compiled as a separate library, and not as a header-only include.

# Benefits

Fixes builds, where pmp is used as an external dependency.

# Drawbacks

None that I know off.

# Applicable Issues

None
