### PR TITLE
[FIX]: Write vertex normal indices only if vertex normals are already written

### DIFF
--- a/src/pmp/io/write_obj.cpp
+++ b/src/pmp/io/write_obj.cpp
@@ -33,7 +33,8 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
 
     // write normals
     auto normals = mesh.get_vertex_property<Normal>("v:normal");
-    if (normals && flags.use_vertex_normals)
+    const bool write_normals = normals && flags.use_vertex_normals;
+    if (write_normals)
     {
         for (auto v : mesh.vertices())
         {
@@ -67,18 +68,31 @@ void write_obj(const SurfaceMesh& mesh, const std::filesystem::path& file,
         auto h = mesh.halfedges(f);
         for (auto v : mesh.vertices(f))
         {
-            auto idx = v.idx() + 1;
+            auto idx = (uint32_t)(v.idx() + 1);
             if (write_texcoords)
             {
-                // write vertex index, texCoord index and normal index
-                fprintf(out, " %d/%d/%d", (uint32_t)idx,
-                        (uint32_t)(*h).idx() + 1, (uint32_t)idx);
+                if (write_normals)
+                {
+                    // write vertex index, texCoord index and normal index
+                    fprintf(out, " %d/%d/%d", idx, (uint32_t)(*h).idx() + 1,
+                            idx);
+                }
+                else
+                {
+                    // write vertex index, texCoord index
+                    fprintf(out, " %d/%d/", idx, (uint32_t)(*h).idx() + 1);
+                }
                 ++h;
+            }
+            else if (write_normals)
+            {
+                // write vertex index and normal index
+                fprintf(out, " %d//%d", idx, idx);
             }
             else
             {
-                // write vertex index and normal index
-                fprintf(out, " %d//%d", (uint32_t)idx, (uint32_t)idx);
+                // write only vertex index
+                fprintf(out, " %d", idx);
             }
         }
         fprintf(out, "\n");


### PR DESCRIPTION
# Description

The current OBJ writer writes the vertex normal indices in all cases; whether vertex normals themselves are written or not. This behavior makes the file size huge for the case of not writing vertex normals.

# Motivation

OBJ writer adds unnecessary vertex normals indices.

# Benefits

Reducing OBJ file size in some cases

# Drawbacks

NO Drawbacks

# Applicable Issues

NO, there is not