### PR TITLE
Add vertex without duplication

### DIFF
--- a/src/pmp/surface_mesh.cpp
+++ b/src/pmp/surface_mesh.cpp
@@ -47,6 +47,8 @@ SurfaceMesh& SurfaceMesh::operator=(const SurfaceMesh& rhs)
         deleted_edges_ = rhs.deleted_edges_;
         deleted_faces_ = rhs.deleted_faces_;
 
+        unique_vertices_set_ = rhs.unique_vertices_set_;
+
         has_garbage_ = rhs.has_garbage_;
     }
 
@@ -83,6 +85,8 @@ SurfaceMesh& SurfaceMesh::assign(const SurfaceMesh& rhs)
         edeleted_.array() = rhs.edeleted_.array();
         fdeleted_.array() = rhs.fdeleted_.array();
 
+        unique_vertices_set_ = rhs.unique_vertices_set_;
+
         // resize (needed by property containers)
         vprops_.resize(rhs.vertices_size());
         hprops_.resize(rhs.halfedges_size());
@@ -118,6 +122,8 @@ void SurfaceMesh::clear()
     vdeleted_ = add_vertex_property<bool>("v:deleted", false);
     edeleted_ = add_edge_property<bool>("e:deleted", false);
     fdeleted_ = add_face_property<bool>("f:deleted", false);
+
+    unique_vertices_set_.clear();
 
     // set initial status (as in constructor)
     deleted_vertices_ = 0;
@@ -192,6 +198,23 @@ Vertex SurfaceMesh::add_vertex(const Point& p)
     Vertex v = new_vertex();
     if (v.is_valid())
         vpoint_[v] = p;
+    return v;
+}
+
+Vertex SurfaceMesh::add_vertex_unique(const Point& p)
+{
+    Vertex v;
+    unique_vertices_point_ = p;
+    auto it = unique_vertices_set_.lower_bound(Vertex());
+
+    if (it == unique_vertices_set_.end() ||
+        p != position(*it) || is_deleted(*it))
+    {
+        v = add_vertex(p);  // unique point
+        unique_vertices_set_.insert(it, v);
+    }
+    else
+        v = *it;  // duplicate
     return v;
 }
 
@@ -1121,6 +1144,16 @@ void SurfaceMesh::garbage_collection()
     for (size_t i = 0; i < nf; ++i)
         fmap[Face(i)] = Face(i);
 
+    // remove deleted vertices from unique_vertices_set_
+    for (auto it = unique_vertices_set_.begin();
+             it != unique_vertices_set_.end(); )
+    {
+        if ((*it).idx() >= nv || is_deleted(*it))
+            it = unique_vertices_set_.erase(it);
+        else
+            ++it;
+    }
+
     // remove deleted vertices
     if (nv > 0)
     {
@@ -1143,6 +1176,20 @@ void SurfaceMesh::garbage_collection()
 
         // remember new size
         nv = vdeleted_[Vertex(i0)] ? i0 : i0 + 1;
+    }
+
+    // reload unique vertices
+    for (auto it = unique_vertices_set_.begin();
+             it != unique_vertices_set_.end(); )
+    {
+        if ((*it).idx() >= vmap[*it].idx())
+        {
+            Vertex v = vmap[*it];
+            it = unique_vertices_set_.erase(it);
+            unique_vertices_set_.insert(it, v);
+        }
+        else
+            ++it;
     }
 
     // remove deleted edges

--- a/tests/surface_mesh_test.cpp
+++ b/tests/surface_mesh_test.cpp
@@ -69,6 +69,40 @@ TEST_F(SurfaceMeshTest, insert_remove_single_polygonal_face)
     EXPECT_EQ(mesh.n_faces(), size_t(0));
 }
 
+TEST_F(SurfaceMeshTest, add_vertex_unique)
+{
+    std::vector<Vertex> v(8);
+    v[0] = mesh.add_vertex_unique(Point(0, 0, 0));
+    v[1] = mesh.add_vertex_unique(Point(1, 0, 0));
+    v[2] = mesh.add_vertex_unique(Point(0, 1, 0));
+    v[3] = mesh.add_vertex_unique(Point(0, 0, 1));
+    v[4] = mesh.add_vertex_unique(Point(0, 0, 0));
+    v[5] = mesh.add_vertex_unique(Point(1, 0, 0));
+    v[6] = mesh.add_vertex_unique(Point(0, 1, 0));
+    v[7] = mesh.add_vertex_unique(Point(0, 0, 1));
+    EXPECT_EQ(v[0], v[4]);
+    EXPECT_EQ(v[1], v[5]);
+    EXPECT_EQ(v[2], v[6]);
+    EXPECT_EQ(v[3], v[7]);
+    mesh.add_triangle(v[0], v[1], v[3]);
+    mesh.add_triangle(v[1], v[2], v[3]);
+    mesh.add_triangle(v[2], v[0], v[3]);
+    mesh.add_triangle(v[0], v[2], v[1]);
+    mesh.delete_vertex(v[2]);
+    v[2] = mesh.add_vertex_unique(Point(0, 1, 0));
+    v[6] = mesh.add_vertex_unique(Point(0, 1, 0));
+    EXPECT_EQ(v[2], v[6]);
+    mesh.garbage_collection();
+    v[0] = mesh.add_vertex_unique(Point(0, 0, 0));
+    v[1] = mesh.add_vertex_unique(Point(1, 0, 0));
+    v[2] = mesh.add_vertex_unique(Point(0, 1, 0));
+    v[3] = mesh.add_vertex_unique(Point(0, 0, 1));
+    EXPECT_EQ(v[0].idx(), IndexType(0));
+    EXPECT_EQ(v[1].idx(), IndexType(1));
+    EXPECT_EQ(v[2].idx(), IndexType(2));
+    EXPECT_EQ(v[3].idx(), IndexType(3));
+}
+
 TEST_F(SurfaceMeshTest, delete_center_vertex)
 {
     mesh = vertex_onering();


### PR DESCRIPTION
# Description

Maintain a set of unique vertices with the "add_vertex_unique()" interface. If a vertex is already in the set it will be returned rather than creating a duplicate. Any vertices added with the "add_vertex()" interface are not added to the unique set. Both interfaces may be used together.

# Motivation

The "add_vertex_unique()" interface takes the burden of having to pre-process the vertices and to remove duplicates. While OpenGL can certainly handle the duplicates, it is more efficient to generate a unique set. Because the new interface works well with "add_vertex()", the user can add duplicate vertices when sharp features are needed.

In order to do further processing such as decimate or remeshing, the mesh must be stitched together where triangles share vertices rather than each triangle having independent vertices. This interface makes it much easier to join triangles.

# Benefits

This approach is especially useful in scalar field iso-surface generation, where each voxel is processed independently. In this case, duplicate vertices need to be merged with existing vertices so the mesh can be stitched together. This eliminates the need to pre-process the vertices prior to creating a mesh.

Mesh object files can also contain duplicates that need to be stitched together to allow further processing such as decimate or remeshing.

# Drawbacks

Since the vertices are added by position, normals are not processed or used to compare equality. Since normals are handled as a vertex property, it does not make sense to include normals in the comparison.

# Applicable Issues

The memory cost per vertex is determined by std::set\<Vertex\>, and only incurred when "add_vertex_unique()" is called.

The initial implementation used a sorted std:vector\<Vertex\>, but the performance cost was too high. std::set uses more memory but delivers great performance, even with very large meshes.

The performance cost is very small. Here are some measurements:
[Results.txt](https://github.com/user-attachments/files/20128546/Results.txt)