### PR TITLE
Fix compilation error for GCC 15

### DIFF
--- a/src/pmp/types.h
+++ b/src/pmp/types.h
@@ -36,10 +36,10 @@ using TexCoord = Vector<Scalar, 2>;
 // define index type to be used
 #ifdef PMP_INDEX_TYPE_64
 using IndexType = std::uint_least64_t;
-#define PMP_MAX_INDEX UINT_LEAST64_MAX
+#define PMP_MAX_INDEX (UINT_LEAST64_MAX - 1)
 #else
 using IndexType = std::uint_least32_t;
-#define PMP_MAX_INDEX UINT_LEAST32_MAX
+#define PMP_MAX_INDEX (UINT_LEAST32_MAX - 1)
 #endif
 
 //! @}


### PR DESCRIPTION
# Description

PMP_MAX_INDEX is possibly out of bounds by 3 elements for std::memset. This change lowers the maximum value and invalid index value for Handles to avoid out-of-bounds access.

# Motivation

- GCC 15 introduces enhanced compile-time diagnostics for detecting out-of-bounds operations.

# Benefits

- Compatibility with GCC >= 15.0.

